### PR TITLE
make unsafe usages more safe

### DIFF
--- a/src/elements/primitives.rs
+++ b/src/elements/primitives.rs
@@ -190,7 +190,7 @@ impl Deserialize for VarInt7 {
         // expand sign
         if u8buf[0] & 0b0100_0000 == 0b0100_0000 { u8buf[0] |= 0b1000_0000 }
         // todo check range
-        Ok(VarInt7(unsafe { ::std::mem::transmute (u8buf[0]) }))
+        Ok(VarInt7(u8buf[0] as i8))
     }
 }
 

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -9,7 +9,7 @@ use interpreter::module::{ModuleInstanceInterface, ModuleInstance, ExecutionPara
 	ItemIndex, CallerContext};
 use interpreter::memory::{MemoryInstance, LINEAR_MEMORY_PAGE_SIZE};
 use interpreter::table::TableInstance;
-use interpreter::value::{RuntimeValue, TransmuteInto};
+use interpreter::value::RuntimeValue;
 use interpreter::variable::VariableInstance;
 
 /// Memory address, at which stack begins.
@@ -169,23 +169,23 @@ pub fn env_module(params: EnvParams) -> Result<EnvModuleInstance, Error> {
 			.build()
 			.with_export(ExportEntry::new("table".into(), Internal::Table(INDEX_TABLE)))
 		// globals
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const(DEFAULT_STACK_BASE.transmute_into())])))
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const(DEFAULT_STACK_BASE as i32)])))
 			.with_export(ExportEntry::new("STACK_BASE".into(), Internal::Global(INDEX_GLOBAL_STACK_BASE)))
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const(DEFAULT_STACK_BASE.transmute_into())])))
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const(DEFAULT_STACK_BASE as i32)])))
 			.with_export(ExportEntry::new("STACKTOP".into(), Internal::Global(INDEX_GLOBAL_STACK_TOP)))
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack).transmute_into())])))
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack) as i32)])))
 			.with_export(ExportEntry::new("STACK_MAX".into(), Internal::Global(INDEX_GLOBAL_STACK_MAX)))
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack).transmute_into())])))
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack) as i32)])))
 			.with_export(ExportEntry::new("DYNAMIC_BASE".into(), Internal::Global(INDEX_GLOBAL_DYNAMIC_BASE)))
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack).transmute_into())])))
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const((DEFAULT_STACK_BASE + params.total_stack) as i32)])))
 			.with_export(ExportEntry::new("DYNAMICTOP_PTR".into(), Internal::Global(INDEX_GLOBAL_DYNAMICTOP_PTR)))
-			.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, params.allow_memory_growth), InitExpr::new(vec![Opcode::I32Const(params.total_memory.transmute_into())])))
+			.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, params.allow_memory_growth), InitExpr::new(vec![Opcode::I32Const(params.total_memory as i32)])))
 			.with_export(ExportEntry::new("TOTAL_MEMORY".into(), Internal::Global(INDEX_GLOBAL_TOTAL_MEMORY)))
 		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const(0)])))
 			.with_export(ExportEntry::new("ABORT".into(), Internal::Global(INDEX_GLOBAL_ABORT)))
 		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, true), InitExpr::new(vec![Opcode::I32Const(0)])))
 			.with_export(ExportEntry::new("EXITSTATUS".into(), Internal::Global(INDEX_GLOBAL_EXIT_STATUS)))
-		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const(DEFAULT_TABLE_BASE.transmute_into())]))) // TODO: what is this?
+		.with_global(GlobalEntry::new(GlobalType::new(ValueType::I32, false), InitExpr::new(vec![Opcode::I32Const(DEFAULT_TABLE_BASE as i32)]))) // TODO: what is this?
 			.with_export(ExportEntry::new("tableBase".into(), Internal::Global(INDEX_GLOBAL_TABLE_BASE)))
 		// functions
 		.function()

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -9,7 +9,7 @@ use interpreter::program::ProgramInstanceEssence;
 use interpreter::runner::{Interpreter, FunctionContext};
 use interpreter::stack::StackWithLimit;
 use interpreter::table::TableInstance;
-use interpreter::value::{RuntimeValue, TryInto, TransmuteInto};
+use interpreter::value::{RuntimeValue, TryInto};
 use interpreter::variable::{VariableInstance, VariableType};
 
 #[derive(Default, Clone)]
@@ -421,8 +421,8 @@ fn get_initializer(expr: &InitExpr, module: &Module, imports: &ModuleImports) ->
 		},
 		&Opcode::I32Const(val) => Ok(RuntimeValue::I32(val)),
 		&Opcode::I64Const(val) => Ok(RuntimeValue::I64(val)),
-		&Opcode::F32Const(val) => Ok(RuntimeValue::F32(val.transmute_into())),
-		&Opcode::F64Const(val) => Ok(RuntimeValue::F64(val.transmute_into())),
+		&Opcode::F32Const(val) => Ok(RuntimeValue::decode_f32(val)),
+		&Opcode::F64Const(val) => Ok(RuntimeValue::decode_f64(val)),
 		_ => Err(Error::Initialization(format!("not-supported {:?} instruction in instantiation-time initializer", first_opcode))),
 	}
 }

--- a/src/interpreter/runner.rs
+++ b/src/interpreter/runner.rs
@@ -8,8 +8,10 @@ use elements::{Opcode, BlockType, FunctionType};
 use interpreter::Error;
 use interpreter::module::{ModuleInstance, ModuleInstanceInterface, CallerContext, ItemIndex};
 use interpreter::stack::StackWithLimit;
-use interpreter::value::{RuntimeValue, TryInto, WrapInto, TryTruncateInto, ExtendInto, TransmuteInto,
-	ArithmeticOps, Integer, Float, LittleEndianConvert};
+use interpreter::value::{
+	RuntimeValue, TryInto, WrapInto, TryTruncateInto, ExtendInto,
+	ArithmeticOps, Integer, Float, LittleEndianConvert, TransmuteInto,
+};
 use interpreter::variable::VariableInstance;
 
 const DEFAULT_MEMORY_INDEX: u32 = 0;


### PR DESCRIPTION
Most of the unsafe calls to `transmute` could be removed with a simple `as` cast.

The unsafe casts from bytes to floats were actually wrong because they didn't mask out sNAN, which could lead to trap/UB when interpreting programs with carefully crafted constants. More discussion here: https://github.com/rust-lang/rust/pull/39271/

We should set a goal for 0 unsafe code within this crate: it should be possible once the methods in the above PR are stabilized.