### PR TITLE
Add a "roundtrip" example which deserializes and serializes a module.

### DIFF
--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -1,0 +1,15 @@
+extern crate parity_wasm;
+
+use std::env;
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() != 3 {
+        println!("Usage: {} in.wasm out.wasm", args[0]);
+        return;
+    }
+
+    let module = parity_wasm::deserialize_file(&args[1]).expect("Failed to load module");
+
+    parity_wasm::serialize_to_file(&args[2], module).expect("Failed to write module");
+}


### PR DESCRIPTION
A tool which does a round trip from serialized form to memory back to serialized form is handy for testing whether deserialization and serialization are lossless.