### PR TITLE
Represent function locals as RuntimeValues.

### DIFF
--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -383,7 +383,7 @@ impl<'a> CallerContext<'a> {
 	}
 }
 
-fn prepare_function_locals(function_type: &FunctionType, function_body: &FuncBody, outer: &mut CallerContext) -> Result<Vec<VariableInstance>, Error> {
+fn prepare_function_locals(function_type: &FunctionType, function_body: &FuncBody, outer: &mut CallerContext) -> Result<Vec<RuntimeValue>, Error> {
 	// locals = function arguments + defined locals
 	function_type.params().iter().rev()
 		.map(|param_type| {
@@ -394,13 +394,13 @@ fn prepare_function_locals(function_type: &FunctionType, function_body: &FuncBod
 				return Err(Error::Function(format!("invalid parameter type {:?} when expected {:?}", actual_type, expected_type)));
 			}
 
-			VariableInstance::new(true, expected_type, param_value)
+			Ok(param_value)
 		})
 		.collect::<Vec<_>>().into_iter().rev()
 		.chain(function_body.locals()
 			.iter()
 			.flat_map(|l| repeat(l.value_type().into()).take(l.count() as usize))
-			.map(|vt| VariableInstance::new(true, vt, RuntimeValue::default(vt))))
+			.map(|vt| Ok(RuntimeValue::default(vt))))
 		.collect::<Result<Vec<_>, _>>()
 }
 

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -9,16 +9,15 @@ use interpreter::module::{ModuleInstance, ModuleInstanceInterface, ItemIndex};
 use interpreter::program::ProgramInstance;
 use interpreter::runner::{Interpreter, FunctionContext};
 use interpreter::value::{RuntimeValue, TryInto};
-use interpreter::variable::{VariableInstance, VariableType};
 
 fn run_function_i32(body: &Opcodes, arg: i32) -> Result<i32, Error> {
 	let ftype = FunctionType::new(vec![ValueType::I32], Some(ValueType::I32));
 	let module = ModuleInstance::new(Weak::default(), Module::default()).unwrap();
 	let externals = HashMap::new();
 	let mut context = FunctionContext::new(&module, &externals, 1024, 1024, &ftype, body.elements(), vec![
-			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(arg)).unwrap(),	// arg
-			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(0)).unwrap(),		// local1
-			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(0)).unwrap(),		// local2
+			RuntimeValue::I32(arg),	// arg
+			RuntimeValue::I32(0),	// local1
+			RuntimeValue::I32(0),	// local2
 		])?;
 	Interpreter::run_function(&mut context, body.elements())
 		.map(|v| v.unwrap().try_into().unwrap())


### PR DESCRIPTION
Local variables are never immutable and never accessed from multiple
threads so they don't need full VariableInstances.

Feel free to decline this if it doesn't fit with where you want this code to go. I was just reading the code and found it to be a little clearer this way (and probably slightly more efficient).