### PR TITLE
Move FunctionContext::new's call to push_frame to Interpreter::run_function.

### DIFF
--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -356,7 +356,7 @@ impl ModuleInstanceInterface for ModuleInstance {
 		let value_stack_limit = outer.value_stack_limit;
 		let frame_stack_limit = outer.frame_stack_limit;
 		let locals = prepare_function_locals(actual_function_type, function_body, &mut outer)?;
-		let mut innner = FunctionContext::new(self, outer.externals, value_stack_limit, frame_stack_limit, actual_function_type, function_code, locals)?;
+		let mut innner = FunctionContext::new(self, outer.externals, value_stack_limit, frame_stack_limit, actual_function_type, locals);
 		Interpreter::run_function(&mut innner, function_code)
 	}
 }

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -15,11 +15,11 @@ fn run_function_i32(body: &Opcodes, arg: i32) -> Result<i32, Error> {
 	let ftype = FunctionType::new(vec![ValueType::I32], Some(ValueType::I32));
 	let module = ModuleInstance::new(Weak::default(), Module::default()).unwrap();
 	let externals = HashMap::new();
-	let mut context = FunctionContext::new(&module, &externals, 1024, 1024, &ftype, body.elements(), vec![
+	let mut context = FunctionContext::new(&module, &externals, 1024, 1024, &ftype, vec![
 			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(arg)).unwrap(),	// arg
 			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(0)).unwrap(),		// local1
 			VariableInstance::new(true, VariableType::I32, RuntimeValue::I32(0)).unwrap(),		// local2
-		])?;
+		]);
 	Interpreter::run_function(&mut context, body.elements())
 		.map(|v| v.unwrap().try_into().unwrap())
 }


### PR DESCRIPTION
This makes it more consistent with run_block and others, and also means
that FunctionContext::new doesn't need to be passed the function body
and doesn't need to return a Result, which simplify its users.
