### PR TITLE
Plain instruction set

### DIFF
--- a/examples/inject.rs
+++ b/examples/inject.rs
@@ -7,16 +7,22 @@ use parity_wasm::builder;
 
 pub fn inject_nop(opcodes: &mut elements::Opcodes) {
     use parity_wasm::elements::Opcode::*;
-    for opcode in opcodes.elements_mut().iter_mut() {
-        match opcode {
-            &mut Block(_, ref mut block) | &mut If(_, ref mut block) => {
-                inject_nop(block)
-            },
-            _ => { }
+    let opcodes = opcodes.elements_mut();
+    let mut position = 0;
+    loop {
+        let need_inject = match &opcodes[position] {
+            &Block(_) | &If(_) => true,
+            _ => false,
+        };
+        if need_inject {
+            opcodes.insert(position + 1, Nop);
+        }
+
+        position += 1;
+        if position >= opcodes.len() {
+            break;
         }
     }
-
-    opcodes.elements_mut().insert(0, Nop);
 }
 
 fn main() {

--- a/src/elements/section.rs
+++ b/src/elements/section.rs
@@ -1016,13 +1016,9 @@ mod tests {
                 FuncBody::new(
                     vec![Local::new(1, ValueType::I32)],
                     Opcodes::new(vec![
-                        Block(
-                            BlockType::Value(ValueType::I32),
-                            Opcodes::new(vec![
-                                GetGlobal(0),
-                                End
-                            ])
-                        ),
+                        Block(BlockType::Value(ValueType::I32)),
+                        GetGlobal(0),
+                        End,
                         End,
                     ])
                 )

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -92,10 +92,6 @@ impl EnvModuleInstance {
 }
 
 impl ModuleInstanceInterface for EnvModuleInstance {
-	/*fn instantiate<'a>(&self, is_user_module: bool, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<(), Error> {
-		self.instance.instantiate(is_user_module, externals)
-	}*/
-
 	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
 		self.instance.execute_index(index, params)
 	}

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -92,9 +92,9 @@ impl EnvModuleInstance {
 }
 
 impl ModuleInstanceInterface for EnvModuleInstance {
-	fn instantiate<'a>(&self, is_user_module: bool, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<(), Error> {
+	/*fn instantiate<'a>(&self, is_user_module: bool, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<(), Error> {
 		self.instance.instantiate(is_user_module, externals)
-	}
+	}*/
 
 	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
 		self.instance.execute_index(index, params)

--- a/src/interpreter/env_native.rs
+++ b/src/interpreter/env_native.rs
@@ -110,9 +110,9 @@ impl<'a> NativeModuleInstance<'a> {
 }
 
 impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
-	fn instantiate<'b>(&self, is_user_module: bool, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<(), Error> {
+	/*fn instantiate<'b>(&self, is_user_module: bool, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<(), Error> {
 		self.env.instantiate(is_user_module, externals)
-	}
+	}*/
 
 	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
 		self.env.execute_index(index, params)

--- a/src/interpreter/env_native.rs
+++ b/src/interpreter/env_native.rs
@@ -110,10 +110,6 @@ impl<'a> NativeModuleInstance<'a> {
 }
 
 impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
-	/*fn instantiate<'b>(&self, is_user_module: bool, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<(), Error> {
-		self.env.instantiate(is_user_module, externals)
-	}*/
-
 	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
 		self.env.execute_index(index, params)
 	}

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -320,8 +320,8 @@ impl ModuleInstance {
 				let mut locals = function_type.params().to_vec();
 				locals.extend(function_body.locals().iter().flat_map(|l| repeat(l.value_type()).take(l.count() as usize)));
 				let mut context = FunctionValidationContext::new(
-					&self.module, 
-					&self.imports, 
+					&self.module,
+					&self.imports,
 					&locals, 
 					DEFAULT_VALUE_STACK_LIMIT, 
 					DEFAULT_FRAME_STACK_LIMIT, 

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -377,7 +377,7 @@ impl ModuleInstance {
 	}
 
 	fn self_ref<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<Arc<ModuleInstanceInterface + 'a>, Error> {
-		self.imports.module(externals, &self.name).map_err(|_| panic!("xxx"))
+		self.imports.module(externals, &self.name)
 	}
 
 	fn require_function(&self, index: ItemIndex) -> Result<u32, Error> {

--- a/src/interpreter/program.rs
+++ b/src/interpreter/program.rs
@@ -33,7 +33,14 @@ impl ProgramInstance {
 
 	/// Instantiate module with validation.
 	pub fn add_module<'a>(&self, name: &str, module: Module, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<Arc<ModuleInstance>, Error> {
-		let module_instance = Arc::new(ModuleInstance::new(Arc::downgrade(&self.essence), name.into(), module)?);
+		let mut module_instance = ModuleInstance::new(Arc::downgrade(&self.essence), name.into(), module)?;
+		module_instance.instantiate(true, externals)?;
+
+		let module_instance = Arc::new(module_instance);
+		self.essence.modules.write().insert(name.into(), module_instance.clone());
+		module_instance.run_start_function()?;
+		Ok(module_instance)
+		/*let module_instance = Arc::new(ModuleInstance::new(Arc::downgrade(&self.essence), name.into(), module)?);
 		self.essence.modules.write().insert(name.into(), module_instance.clone());
 		// replace existing module with the same name with new one
 		match module_instance.instantiate(true, externals) {
@@ -42,21 +49,7 @@ impl ProgramInstance {
 				self.essence.modules.write().remove(name.into());
 				Err(err)
 			}
-		}
-	}
-
-	/// Instantiate module without validation.
-	pub fn add_module_without_validation<'a>(&self, name: &str, module: Module, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<Arc<ModuleInstance>, Error> {
-		let module_instance = Arc::new(ModuleInstance::new(Arc::downgrade(&self.essence), name.into(), module)?);
-		self.essence.modules.write().insert(name.into(), module_instance.clone());
-		// replace existing module with the same name with new one
-		match module_instance.instantiate(false, externals) {
-			Ok(()) => Ok(module_instance),
-			Err(err) => {
-				self.essence.modules.write().remove(name.into());
-				Err(err)
-			}
-		}
+		}*/
 	}
 
 	/// Insert instantiated module.

--- a/src/interpreter/program.rs
+++ b/src/interpreter/program.rs
@@ -40,16 +40,6 @@ impl ProgramInstance {
 		self.essence.modules.write().insert(name.into(), module_instance.clone());
 		module_instance.run_start_function()?;
 		Ok(module_instance)
-		/*let module_instance = Arc::new(ModuleInstance::new(Arc::downgrade(&self.essence), name.into(), module)?);
-		self.essence.modules.write().insert(name.into(), module_instance.clone());
-		// replace existing module with the same name with new one
-		match module_instance.instantiate(true, externals) {
-			Ok(()) => Ok(module_instance),
-			Err(err) => {
-				self.essence.modules.write().remove(name.into());
-				Err(err)
-			}
-		}*/
 	}
 
 	/// Insert instantiated module.

--- a/src/interpreter/runner.rs
+++ b/src/interpreter/runner.rs
@@ -118,8 +118,6 @@ impl Interpreter {
 
 			let function_return = match function_body {
 				Some(function_body) => {
-println!("=== body: {:?}", function_body.body);
-println!("=== labels: {:?}", function_context.function_labels);
 					if !function_context.is_initialized() {
 						let return_type = function_context.return_type;
 						function_context.initialize(function_body.locals, function_body.labels.clone())?;
@@ -162,7 +160,6 @@ println!("=== labels: {:?}", function_context.function_labels);
 			let instruction = &function_body[function_context.position];
 
 			debug!(target: "interpreter", "running {:?}", instruction);
-println!("running {:?} at {}", instruction, function_context.position);
 			match Interpreter::run_instruction(function_context, instruction)? {
 				InstructionOutcome::RunInstruction => (),
 				InstructionOutcome::RunNextInstruction => function_context.position += 1,
@@ -225,7 +222,6 @@ println!("running {:?} at {}", instruction, function_context.position);
 				},
 				InstructionOutcome::Return => break,
 			}
-//println!("=== {:?}", function_context.frame_stack().len());
 		}
 
 		Ok(RunResult::Return(match function_context.return_type {
@@ -235,7 +231,6 @@ println!("running {:?} at {}", instruction, function_context.position);
 	}
 
 	fn run_instruction<'a, 'b>(context: &'b mut FunctionContext<'a>, opcode: &Opcode) -> Result<InstructionOutcome<'a>, Error> {
-//println!("running {:?}", opcode);
 		match opcode {
 			&Opcode::Unreachable => Interpreter::run_unreachable(context),
 			&Opcode::Nop => Interpreter::run_nop(context),
@@ -450,10 +445,7 @@ println!("running {:?} at {}", instruction, function_context.position);
 	fn run_if<'a, 'b>(context: &'b mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
 		let branch = context.value_stack_mut().pop_as()?;
 		let block_frame_type = if branch { BlockFrameType::IfTrue } else {
-//println!("=== position = {}", context.position);
 			let else_pos = context.function_labels[&context.position];
-//println!("=== else_pos = {}", else_pos);
-//println!("=== labels[else_pos] = {:?}", context.function_labels.get(&else_pos));
 			if !context.function_labels.contains_key(&else_pos) {
 				context.position = else_pos;
 				return Ok(InstructionOutcome::RunNextInstruction);
@@ -1148,7 +1140,6 @@ impl<'a> FunctionContext<'a> {
 		};
 		self.value_stack.resize(frame.value_limit, RuntimeValue::I32(0));
 		self.position = if is_branch { frame.branch_position } else { frame.end_position };
-//println!("=== pop_frame: position = {}", self.position);
 		if let Some(frame_value) = frame_value {
 			self.value_stack.push(frame_value)?;
 		}

--- a/src/interpreter/runner.rs
+++ b/src/interpreter/runner.rs
@@ -156,7 +156,7 @@ impl Interpreter {
 		}))
 	}
 
-	fn run_instruction<'a, 'b>(context: &'b mut FunctionContext<'a>, opcode: &Opcode) -> Result<InstructionOutcome<'a>, Error> {
+	fn run_instruction<'a>(context: &mut FunctionContext<'a>, opcode: &Opcode) -> Result<InstructionOutcome<'a>, Error> {
 		match opcode {
 			&Opcode::Unreachable => Interpreter::run_unreachable(context),
 			&Opcode::Nop => Interpreter::run_nop(context),
@@ -358,17 +358,17 @@ impl Interpreter {
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_block<'a, 'b>(context: &'b mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
+	fn run_block<'a>(context: &mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
 		context.push_frame(BlockFrameType::Block, block_type)?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_loop<'a, 'b>(context: &'b mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
+	fn run_loop<'a>(context: &mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
 		context.push_frame(BlockFrameType::Loop, block_type)?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_if<'a, 'b>(context: &'b mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
+	fn run_if<'a>(context: &mut FunctionContext<'a>, block_type: BlockType) -> Result<InstructionOutcome<'a>, Error> {
 		let branch = context.value_stack_mut().pop_as()?;
 		let block_frame_type = if branch { BlockFrameType::IfTrue } else {
 			let else_pos = context.function_labels[&context.position];
@@ -416,11 +416,11 @@ impl Interpreter {
 		Ok(InstructionOutcome::Return)
 	}
 
-	fn run_call<'a, 'b>(context: &'b mut FunctionContext<'a>, func_idx: u32) -> Result<InstructionOutcome<'a>, Error> where 'a: 'b {
+	fn run_call<'a>(context: &mut FunctionContext<'a>, func_idx: u32) -> Result<InstructionOutcome<'a>, Error> {
 		Ok(InstructionOutcome::ExecuteCall(context.module().function_reference(ItemIndex::IndexSpace(func_idx), Some(context.externals))?))
 	}
 
-	fn run_call_indirect<'a, 'b>(context: &'b mut FunctionContext<'a>, type_idx: u32) -> Result<InstructionOutcome<'a>, Error> {
+	fn run_call_indirect<'a>(context: &mut FunctionContext<'a>, type_idx: u32) -> Result<InstructionOutcome<'a>, Error> {
 		let table_func_idx: u32 = context.value_stack_mut().pop_as()?;
 		let function_reference = context.module().function_reference_indirect(DEFAULT_TABLE_INDEX, type_idx, table_func_idx, Some(context.externals))?;
 		let required_function_type = context.module().function_type_by_index(type_idx)?;

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -46,14 +46,12 @@ impl<T> StackWithLimit<T> where T: Clone {
 		self.values
 			.back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
-.map_err(|_| panic!("1"))
 	}
 
 	pub fn top_mut(&mut self) -> Result<&mut T, Error> {
 		self.values
 			.back_mut()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
-.map_err(|_| panic!("2"))
 	}
 
 	pub fn get(&self, index: usize) -> Result<&T, Error> {
@@ -90,7 +88,6 @@ impl<T> StackWithLimit<T> where T: Clone {
 		self.values
 			.pop_back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
-.map_err(|_| panic!("3"))
 	}
 
 	pub fn resize(&mut self, new_size: usize, dummy: T) {

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -46,12 +46,14 @@ impl<T> StackWithLimit<T> where T: Clone {
 		self.values
 			.back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
+.map_err(|_| panic!("1"))
 	}
 
 	pub fn top_mut(&mut self) -> Result<&mut T, Error> {
 		self.values
 			.back_mut()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
+.map_err(|_| panic!("2"))
 	}
 
 	pub fn get(&self, index: usize) -> Result<&T, Error> {
@@ -88,6 +90,7 @@ impl<T> StackWithLimit<T> where T: Clone {
 		self.values
 			.pop_back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
+.map_err(|_| panic!("3"))
 	}
 
 	pub fn resize(&mut self, new_size: usize, dummy: T) {

--- a/src/interpreter/table.rs
+++ b/src/interpreter/table.rs
@@ -29,6 +29,11 @@ impl TableInstance {
 		}))
 	}
 
+	/// Get variable type for this table.
+	pub fn variable_type(&self) -> VariableType {
+		self.variable_type
+	}
+
 	/// Get the specific value in the table
 	pub fn get(&self, offset: u32) -> Result<RuntimeValue, Error> {
 		let buffer = self.buffer.read();

--- a/src/interpreter/tests/basics.rs
+++ b/src/interpreter/tests/basics.rs
@@ -6,9 +6,8 @@ use elements::{ExportEntry, Internal, ImportEntry, External, GlobalEntry, Global
 	InitExpr, ValueType, BlockType, Opcodes, Opcode, FunctionType};
 use interpreter::Error;
 use interpreter::env_native::{env_native_module, UserFunction, UserFunctions, UserFunctionExecutor, UserFunctionDescriptor};
-use interpreter::imports::ModuleImports;
 use interpreter::memory::MemoryInstance;
-use interpreter::module::{ModuleInstanceInterface, CallerContext, ItemIndex, ExecutionParams, ExportEntryType};
+use interpreter::module::{ModuleInstance, ModuleInstanceInterface, CallerContext, ItemIndex, ExecutionParams, ExportEntryType};
 use interpreter::program::ProgramInstance;
 use interpreter::validator::{FunctionValidationContext, Validator};
 use interpreter::value::RuntimeValue;
@@ -226,9 +225,8 @@ fn env_native_export_entry_type_check() {
 
 #[test]
 fn if_else_with_return_type_validation() {
-	let module = module().build();
-	let imports = ModuleImports::new(Weak::default(), None);
-	let mut context = FunctionValidationContext::new(&module, &imports, &[], 1024, 1024, &FunctionType::default());
+	let module_instance = ModuleInstance::new(Weak::default(), "test".into(), module().build()).unwrap();
+	let mut context = FunctionValidationContext::new(&module_instance, &[], 1024, 1024, &FunctionType::default());
 
 	Validator::validate_function(&mut context, BlockType::NoResult, &[
 		Opcode::I32Const(1),

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -55,13 +55,11 @@ fn nop() {
 #[test]
 fn expr_block() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::Value(ValueType::I32),	// mark block
-			Opcodes::new(vec![
-				Opcode::I32Const(10),		// [10]
-				Opcode::Drop,
-				Opcode::I32Const(1),		// [1]
-				Opcode::End,
-			])),
+		Opcode::Block(BlockType::Value(ValueType::I32)),
+			Opcode::I32Const(10),		// [10]
+			Opcode::Drop,
+			Opcode::I32Const(1),		// [1]
+		Opcode::End,
 		Opcode::End]));
 
 	assert_eq!(run_function_i32(&module, 0).unwrap(), 1);
@@ -71,26 +69,23 @@ fn expr_block() {
 #[test]
 fn loop_test() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Loop(BlockType::NoResult,	// loop
-			Opcodes::new(vec![
-				Opcode::GetLocal(1),		//   [local1]
-				Opcode::GetLocal(0),		//   [local1, arg]
-				Opcode::I32Add,				//   [arg + local1]
-				Opcode::SetLocal(1),		//   [] + local1 = arg + local1
-				Opcode::GetLocal(0),		//   [arg]
-				Opcode::I32Const(1),		//   [arg, 1]
-				Opcode::I32Add,				//   [arg + 1]
-				Opcode::SetLocal(0),		//   [] + arg = arg + 1
-				Opcode::GetLocal(0),		//   [arg]
-				Opcode::I32Const(5),		//   [arg, 5]
-				Opcode::I32LtS,				//   [arg < 5]
-				Opcode::If(BlockType::NoResult,
-					Opcodes::new(vec![
-						Opcode::Br(1),		//   break loop
-						Opcode::End,
-					])),
-				Opcode::End])),				// end loop
-		Opcode::GetLocal(1),				// [local1]
+		Opcode::Loop(BlockType::NoResult),	// loop
+			Opcode::GetLocal(1),		//   [local1]
+			Opcode::GetLocal(0),		//   [local1, arg]
+			Opcode::I32Add,				//   [arg + local1]
+			Opcode::SetLocal(1),		//   [] + local1 = arg + local1
+			Opcode::GetLocal(0),		//   [arg]
+			Opcode::I32Const(1),		//   [arg, 1]
+			Opcode::I32Add,				//   [arg + 1]
+			Opcode::SetLocal(0),		//   [] + arg = arg + 1
+			Opcode::GetLocal(0),		//   [arg]
+			Opcode::I32Const(5),		//   [arg, 5]
+			Opcode::I32LtS,				//   [arg < 5]
+			Opcode::If(BlockType::NoResult),
+				Opcode::Br(1),			//   break loop
+			Opcode::End,
+		Opcode::End,					// end loop
+		Opcode::GetLocal(1),			// [local1]
 		Opcode::End]));
 
 	assert_eq!(run_function_i32(&module, 0).unwrap(), 10);
@@ -103,23 +98,19 @@ fn if_1() {
 		Opcode::I32Const(0),				// [0]
 		Opcode::SetLocal(0),				// [] + arg = 0
 		Opcode::I32Const(1),				// [1]
-		Opcode::If(BlockType::NoResult,		// if 1
-			Opcodes::new(vec![
-				Opcode::GetLocal(0),		//   [arg]
-				Opcode::I32Const(1),		//   [arg, 1]
-				Opcode::I32Add,				//   [arg + 1]
-				Opcode::SetLocal(0),		//   [] + arg = arg + 1
-				Opcode::End,				// end if
-			])),
+		Opcode::If(BlockType::NoResult),	// if 1
+			Opcode::GetLocal(0),			//   [arg]
+			Opcode::I32Const(1),			//   [arg, 1]
+			Opcode::I32Add,					//   [arg + 1]
+			Opcode::SetLocal(0),			//   [] + arg = arg + 1
+		Opcode::End,						// end if
 		Opcode::I32Const(0),				// [0]
-		Opcode::If(BlockType::NoResult,		// if 0
-			Opcodes::new(vec![
-				Opcode::GetLocal(0),		//   [arg]
-				Opcode::I32Const(1),		//   [arg, 1]
-				Opcode::I32Add,				//   [arg + 1]
-				Opcode::SetLocal(0),		//   [] + arg = arg + 1
-				Opcode::End,				// end if
-			])),
+		Opcode::If(BlockType::NoResult),	// if 0
+			Opcode::GetLocal(0),			//   [arg]
+			Opcode::I32Const(1),			//   [arg, 1]
+			Opcode::I32Add,					//   [arg + 1]
+			Opcode::SetLocal(0),			//   [] + arg = arg + 1
+		Opcode::End,						// end if
 		Opcode::GetLocal(0),				// [arg]
 		Opcode::End]));
 
@@ -131,25 +122,21 @@ fn if_1() {
 fn if_2() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
 		Opcode::I32Const(1),				// [1]
-		Opcode::If(BlockType::NoResult,		// if 1
-			Opcodes::new(vec![
-				Opcode::I32Const(1),		//   [1]
-				Opcode::SetLocal(0),		//   [] + arg = 1
-				Opcode::Else,				// else
-				Opcode::I32Const(2),		//   [2]
-				Opcode::SetLocal(0),		//   [] + arg = 2
-				Opcode::End,				// end if
-			])),
+		Opcode::If(BlockType::NoResult),	// if 1
+			Opcode::I32Const(1),			//   [1]
+			Opcode::SetLocal(0),			//   [] + arg = 1
+		Opcode::Else,						// else
+			Opcode::I32Const(2),			//   [2]
+			Opcode::SetLocal(0),			//   [] + arg = 2
+		Opcode::End,						// end if
 		Opcode::I32Const(0),				// [0]
-		Opcode::If(BlockType::NoResult,		// if 0
-			Opcodes::new(vec![
-				Opcode::I32Const(4),		//   [4]
-				Opcode::SetLocal(1),		//   [] + local1 = 4
-				Opcode::Else,				// else
-				Opcode::I32Const(8),		//   [8]
-				Opcode::SetLocal(1),		//   [] + local1 = 8
-				Opcode::End,				// end if
-			])),
+		Opcode::If(BlockType::NoResult),	// if 0
+			Opcode::I32Const(4),			//   [4]
+			Opcode::SetLocal(1),			//   [] + local1 = 4
+		Opcode::Else,						// else
+			Opcode::I32Const(8),			//   [8]
+			Opcode::SetLocal(1),			//   [] + local1 = 8
+		Opcode::End,						// end if
 		Opcode::GetLocal(0),				// [arg]
 		Opcode::GetLocal(1),				// [arg, local1]
 		Opcode::I32Add,						// [arg + local1]
@@ -165,13 +152,11 @@ fn expr_if() {
 		Opcode::GetLocal(0),							// [arg]
 		Opcode::I32Const(0),							// [arg, 0]
 		Opcode::I32Eq,									// [arg == 0]
-		Opcode::If(BlockType::Value(ValueType::I32),	// if arg == 0
-			Opcodes::new(vec![
-				Opcode::I32Const(1),					//   [1]
-				Opcode::Else,							// else
-				Opcode::I32Const(2),					//   [2]
-				Opcode::End,							// end if
-			])),
+		Opcode::If(BlockType::Value(ValueType::I32)),	// if arg == 0
+			Opcode::I32Const(1),						//   [1]
+		Opcode::Else,									// else
+			Opcode::I32Const(2),						//   [2]
+		Opcode::End,									// end if
 		Opcode::End]));
 
 	assert_eq!(run_function_i32(&module, 0).unwrap(), 1);
@@ -182,23 +167,17 @@ fn expr_if() {
 #[test]
 fn nested_if() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,
-			Opcodes::new(vec![
-				Opcode::I32Const(1),
-				Opcode::If(BlockType::NoResult,
-					Opcodes::new(vec![
-						Opcode::I32Const(2),
-						Opcode::Drop,
-						Opcode::I32Const(3),
-						Opcode::If(BlockType::NoResult,
-							Opcodes::new(vec![
-								Opcode::Br(2),
-								Opcode::End,
-							])),
-						Opcode::End,
-					])),
+		Opcode::Block(BlockType::NoResult),
+			Opcode::I32Const(1),
+			Opcode::If(BlockType::NoResult),
+				Opcode::I32Const(2),
+				Opcode::Drop,
+				Opcode::I32Const(3),
+				Opcode::If(BlockType::NoResult),
+					Opcode::Br(2),
 				Opcode::End,
-			])),
+			Opcode::End,
+		Opcode::End,
 		Opcode::I32Const(4),
 		Opcode::End]));
 
@@ -209,18 +188,14 @@ fn nested_if() {
 #[test]
 fn br_0() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,			// mark block
-			Opcodes::new(vec![
-				Opcode::I32Const(1),				//   [1]
-				Opcode::If(BlockType::NoResult,		//   if 1
-					Opcodes::new(vec![
-						Opcode::Br(1),				//     break from block
-						Opcode::End,				//   end if
-					])),
-				Opcode::I32Const(1),				//   [1]
-				Opcode::SetLocal(0),				//   [] + arg = 1
-				Opcode::End,						// end block
-			])),
+		Opcode::Block(BlockType::NoResult),			// mark block
+			Opcode::I32Const(1),					//   [1]
+			Opcode::If(BlockType::NoResult),		//   if 1
+				Opcode::Br(1),						//     break from block
+			Opcode::End,							//   end if
+			Opcode::I32Const(1),					//   [1]
+			Opcode::SetLocal(0),					//   [] + arg = 1
+		Opcode::End,								// end block
 		Opcode::I32Const(1),						// [1]
 		Opcode::SetLocal(1),						// [] + local1 = 1
 		Opcode::GetLocal(0),						// [arg]
@@ -239,24 +214,18 @@ fn br_0() {
 #[test]
 fn br_1() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,					// block1
-			Opcodes::new(vec![
-				Opcode::Block(BlockType::NoResult,			//   block2
-					Opcodes::new(vec![
-						Opcode::I32Const(1),				//     [1]
-						Opcode::If(BlockType::NoResult,		//     if 1
-							Opcodes::new(vec![
-								Opcode::Br(2),				//       break from block2
-								Opcode::End,				//     end if
-							])),
-						Opcode::I32Const(1),				//     [1]
-						Opcode::SetLocal(0),				//     [] + arg = 1
-						Opcode::End,						//   end (block2)
-					])),
-				Opcode::I32Const(1),						//   [1]
-				Opcode::SetLocal(1),						//   [] + local1 = 1
-				Opcode::End,								// end (block1)
-			])),
+		Opcode::Block(BlockType::NoResult),					// block1
+			Opcode::Block(BlockType::NoResult),				//   block2
+				Opcode::I32Const(1),						//     [1]
+				Opcode::If(BlockType::NoResult),			//     if 1
+					Opcode::Br(2),							//       break from block2
+				Opcode::End,								//     end if
+				Opcode::I32Const(1),						//     [1]
+				Opcode::SetLocal(0),						//     [] + arg = 1
+			Opcode::End,									//   end (block2)
+			Opcode::I32Const(1),							//   [1]
+			Opcode::SetLocal(1),							//   [] + local1 = 1
+		Opcode::End,										// end (block1)
 		Opcode::I32Const(1),								// [1]
 		Opcode::SetLocal(2),								// [] + local2 = 1
 		Opcode::GetLocal(0),								// [arg]
@@ -279,22 +248,16 @@ fn br_1() {
 #[test]
 fn br_2() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,					// block1
-			Opcodes::new(vec![
-				Opcode::Block(BlockType::NoResult,			//   block2
-					Opcodes::new(vec![
-						Opcode::I32Const(1),				//     [1]
-						Opcode::If(BlockType::NoResult,		//     if 1
-							Opcodes::new(vec![
-								Opcode::Br(2),				//       break from block2
-								Opcode::End,				//     end if
-							])),
-						Opcode::I32Const(1),				//     [1]
-						Opcode::Return,						//     return 1
-						Opcode::End,						//   end (block2)
-					])),
-				Opcode::End,								// end (block1)
-			])),
+		Opcode::Block(BlockType::NoResult),					// block1
+			Opcode::Block(BlockType::NoResult),				//   block2
+				Opcode::I32Const(1),						//     [1]
+				Opcode::If(BlockType::NoResult),			//     if 1
+					Opcode::Br(2),							//       break from block2
+				Opcode::End,								//     end if
+				Opcode::I32Const(1),						//     [1]
+				Opcode::Return,								//     return 1
+			Opcode::End,									//   end (block2)
+		Opcode::End,										// end (block1)
 		Opcode::I32Const(2),								// [2]
 		Opcode::Return,										// return 2
 		Opcode::End]));
@@ -306,37 +269,29 @@ fn br_2() {
 #[test]
 fn br_3() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,					// block1
-			Opcodes::new(vec![
-				Opcode::Loop(BlockType::NoResult,			//   loop
-					Opcodes::new(vec![
-						Opcode::GetLocal(0),				//     [arg]
-						Opcode::I32Const(1),				//     [arg, 1]
-						Opcode::I32Add,						//     [arg + 1]
-						Opcode::SetLocal(0),				//     [] + arg = arg + 1
-						Opcode::GetLocal(0),				//     [arg]
-						Opcode::I32Const(5),				//     [arg, 5]
-						Opcode::I32GeS,						//     [5 >= arg]
-						Opcode::If(BlockType::NoResult,		//     if 5 >= arg
-							Opcodes::new(vec![
-								Opcode::Br(2),				//       break from block1
-								Opcode::End,				//     end
-							])),
-						Opcode::GetLocal(0),				//     [arg]
-						Opcode::I32Const(4),				//     [arg, 4]
-						Opcode::I32Eq,						//     [arg == 4]
-						Opcode::If(BlockType::NoResult,		//     if arg == 4
-							Opcodes::new(vec![
-								Opcode::Br(1),				//       break from loop
-								Opcode::End,				//     end
-							])),
-						Opcode::GetLocal(0),				//     [arg]
-						Opcode::SetLocal(1),				//     [] + local1 = arg
-						Opcode::Br(0),						//     continue loop
-						Opcode::End,						//   end (loop)
-					])),
-				Opcode::End,								// end (block1)
-			])),
+		Opcode::Block(BlockType::NoResult),					// block1
+			Opcode::Loop(BlockType::NoResult),				//   loop
+				Opcode::GetLocal(0),						//     [arg]
+				Opcode::I32Const(1),						//     [arg, 1]
+				Opcode::I32Add,								//     [arg + 1]
+				Opcode::SetLocal(0),						//     [] + arg = arg + 1
+				Opcode::GetLocal(0),						//     [arg]
+				Opcode::I32Const(5),						//     [arg, 5]
+				Opcode::I32GeS,								//     [5 >= arg]
+				Opcode::If(BlockType::NoResult),			//     if 5 >= arg
+					Opcode::Br(2),							//       break from block1
+				Opcode::End,								//     end
+				Opcode::GetLocal(0),						//     [arg]
+				Opcode::I32Const(4),						//     [arg, 4]
+				Opcode::I32Eq,								//     [arg == 4]
+				Opcode::If(BlockType::NoResult),			//     if arg == 4
+					Opcode::Br(1),							//       break from loop
+				Opcode::End,								//     end
+				Opcode::GetLocal(0),						//     [arg]
+				Opcode::SetLocal(1),						//     [] + local1 = arg
+				Opcode::Br(0),								//     continue loop
+			Opcode::End,									//   end (loop)
+		Opcode::End,										// end (block1)
 		Opcode::GetLocal(1),								// [local1]
 		Opcode::Return,										// return local1
 		Opcode::End]));
@@ -348,20 +303,16 @@ fn br_3() {
 #[test]
 fn expr_br() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::Value(ValueType::I32),		// block1
-			Opcodes::new(vec![
-				Opcode::GetLocal(0),						//   [arg]
-				Opcode::I32Const(0),						//   [arg, 0]
-				Opcode::I32Eq,								//   [arg == 0]
-				Opcode::If(BlockType::NoResult,				//   if arg == 0
-					Opcodes::new(vec![
-						Opcode::I32Const(1),				//     [1]
-						Opcode::Br(1),						//     break from block1
-						Opcode::End,						//   end (if)
-					])),
-				Opcode::I32Const(2),						//   [2]
-				Opcode::End,								// end (block1)
-			])),
+		Opcode::Block(BlockType::Value(ValueType::I32)),	// block1
+			Opcode::GetLocal(0),							//   [arg]
+			Opcode::I32Const(0),							//   [arg, 0]
+			Opcode::I32Eq,									//   [arg == 0]
+			Opcode::If(BlockType::NoResult),				//   if arg == 0
+				Opcode::I32Const(1),						//     [1]
+				Opcode::Br(1),								//     break from block1
+			Opcode::End,									//   end (if)
+			Opcode::I32Const(2),							//   [2]
+		Opcode::End,										// end (block1)
 		Opcode::End]));
 
 	assert_eq!(run_function_i32(&module, 0).unwrap(), 1);
@@ -372,14 +323,12 @@ fn expr_br() {
 #[test]
 fn brif() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,					// block1
-			Opcodes::new(vec![
-				Opcode::GetLocal(0),						//   [arg]
-				Opcode::BrIf(0),							//   if arg != 0: break from block1
-				Opcode::I32Const(1),						//   [1]
-				Opcode::Return,								//   return 1
-				Opcode::End,								// end (block1)
-			])),
+		Opcode::Block(BlockType::NoResult),					// block1
+			Opcode::GetLocal(0),							//   [arg]
+			Opcode::BrIf(0),								//   if arg != 0: break from block1
+			Opcode::I32Const(1),							//   [1]
+			Opcode::Return,									//   return 1
+		Opcode::End,										// end (block1)
 		Opcode::I32Const(2),								// [2]
 		Opcode::Return,										// return 2
 		Opcode::End]));
@@ -392,18 +341,16 @@ fn brif() {
 #[test]
 fn brif_loop() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Loop(BlockType::NoResult,					// loop
-			Opcodes::new(vec![
-				Opcode::GetLocal(1),						//   [local1]
-				Opcode::I32Const(1),						//   [local1, 1]
-				Opcode::I32Add,								//   [local1 + 1]
-				Opcode::SetLocal(1),						//   [] + local1 = local1 + 1
-				Opcode::GetLocal(1),						//   [local1]
-				Opcode::GetLocal(0),						//   [local1, arg]
-				Opcode::I32LtS,								//   [local1 < arg]
-				Opcode::BrIf(0),							//   break loop if local1 < arg
-				Opcode::End,								// end (loop)
-			])),
+		Opcode::Loop(BlockType::NoResult),					// loop
+			Opcode::GetLocal(1),							//   [local1]
+			Opcode::I32Const(1),							//   [local1, 1]
+			Opcode::I32Add,									//   [local1 + 1]
+			Opcode::SetLocal(1),							//   [] + local1 = local1 + 1
+			Opcode::GetLocal(1),							//   [local1]
+			Opcode::GetLocal(0),							//   [local1, arg]
+			Opcode::I32LtS,									//   [local1 < arg]
+			Opcode::BrIf(0),								//   break loop if local1 < arg
+		Opcode::End,										// end (loop)
 		Opcode::GetLocal(1),								// [local1]
 		Opcode::Return,										// return
 		Opcode::End]));
@@ -416,18 +363,16 @@ fn brif_loop() {
 #[test]
 fn expr_brif() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Loop(BlockType::NoResult,		// loop
-			Opcodes::new(vec![
-				Opcode::GetLocal(1),			//   [local1]
-				Opcode::I32Const(1),			//   [local1, 1]
-				Opcode::I32Add,					//   [local1 + 1]
-				Opcode::SetLocal(1),			//   [] + local1 = local1 + 1
-				Opcode::GetLocal(1),			//   [local1]
-				Opcode::GetLocal(0),			//   [local1, local0]
-				Opcode::I32LtS,					//   [local1 < local0]
-				Opcode::BrIf(0),				//   if local1 < local0: break from loop
-				Opcode::End,					// end (loop)
-			])),
+		Opcode::Loop(BlockType::NoResult),		// loop
+			Opcode::GetLocal(1),			//   [local1]
+			Opcode::I32Const(1),			//   [local1, 1]
+			Opcode::I32Add,					//   [local1 + 1]
+			Opcode::SetLocal(1),			//   [] + local1 = local1 + 1
+			Opcode::GetLocal(1),			//   [local1]
+			Opcode::GetLocal(0),			//   [local1, local0]
+			Opcode::I32LtS,					//   [local1 < local0]
+			Opcode::BrIf(0),				//   if local1 < local0: break from loop
+		Opcode::End,					// end (loop)
 		Opcode::GetLocal(1),					// [local1]
 		Opcode::End]));
 
@@ -439,30 +384,22 @@ fn expr_brif() {
 #[test]
 fn brtable() {
 	let (_program, module) = make_function_i32(Opcodes::new(vec![
-		Opcode::Block(BlockType::NoResult,										// block3
-			Opcodes::new(vec![
-				Opcode::Block(BlockType::NoResult,								//   block2
-					Opcodes::new(vec![
-						Opcode::Block(BlockType::NoResult,						//     block1
-							Opcodes::new(vec![
-								Opcode::Block(BlockType::NoResult,				//       block0
-									Opcodes::new(vec![
-										Opcode::GetLocal(0),					//         [arg]
-										Opcode::BrTable(vec![0, 1, 2], 3),		//         br_table
-										Opcode::End,							//       end (block0)
-									])),
-								Opcode::I32Const(0),							//       [0]
-								Opcode::Return,									//       return 0
-								Opcode::End,									//     end (block1)
-							])),
-						Opcode::I32Const(1),									//       [1]
-						Opcode::Return,											//       return 1
-						Opcode::End,											//   end (block2)
-					])),
-				Opcode::End,													// end (block3)
-			])),
-		Opcode::I32Const(2),													// [2]
-		Opcode::Return,															// return 2
+		Opcode::Block(BlockType::NoResult),					// block3
+			Opcode::Block(BlockType::NoResult),				//   block2
+				Opcode::Block(BlockType::NoResult),			//     block1
+					Opcode::Block(BlockType::NoResult),		//       block0
+						Opcode::GetLocal(0),				//         [arg]
+						Opcode::BrTable(vec![0, 1, 2], 3),	//         br_table
+					Opcode::End,							//       end (block0)
+					Opcode::I32Const(0),					//       [0]
+					Opcode::Return,							//       return 0
+				Opcode::End,								//     end (block1)
+				Opcode::I32Const(1),						//       [1]
+				Opcode::Return,								//       return 1
+			Opcode::End,									//   end (block2)
+		Opcode::End,										// end (block3)
+		Opcode::I32Const(2),								// [2]
+		Opcode::Return,										// return 2
 		Opcode::End]));
 
 	assert_eq!(run_function_i32(&module, 0).unwrap(), 0);
@@ -478,21 +415,17 @@ fn return_test() {
 		Opcode::GetLocal(0),
 		Opcode::I32Const(0),
 		Opcode::I32Eq,
-		Opcode::If(BlockType::NoResult,
-			Opcodes::new(vec![
-				Opcode::I32Const(1),
-				Opcode::Return,
-				Opcode::End,
-			])),
+		Opcode::If(BlockType::NoResult),
+			Opcode::I32Const(1),
+			Opcode::Return,
+		Opcode::End,
 		Opcode::GetLocal(0),
 		Opcode::I32Const(1),
 		Opcode::I32Eq,
-		Opcode::If(BlockType::NoResult,
-			Opcodes::new(vec![
-				Opcode::I32Const(2),
-				Opcode::Return,
-				Opcode::End,
-			])),
+		Opcode::If(BlockType::NoResult),
+			Opcode::I32Const(2),
+			Opcode::Return,
+		Opcode::End,
 		Opcode::I32Const(3),
 		Opcode::Return,
 		Opcode::End]));
@@ -509,11 +442,9 @@ fn return_void() {
 		Opcode::GetLocal(0),
 		Opcode::I32Const(0),
 		Opcode::I32Eq,
-		Opcode::If(BlockType::NoResult,
-			Opcodes::new(vec![
-				Opcode::Return,
-				Opcode::End,
-			])),
+		Opcode::If(BlockType::NoResult),
+			Opcode::Return,
+		Opcode::End,
 		Opcode::I32Const(0),
 		Opcode::I32Const(1),
 		Opcode::I32Store(2, 0),
@@ -604,20 +535,18 @@ fn call_2() {
 		Opcode::GetLocal(0),
 		Opcode::I32Const(0),
 		Opcode::I32GtS,
-		Opcode::If(BlockType::Value(ValueType::I32),
-			Opcodes::new(vec![
-				Opcode::GetLocal(0),
-				Opcode::GetLocal(0),
-				Opcode::I32Const(1),
-				Opcode::I32Sub,
-				Opcode::Call(1),
-				Opcode::I32Mul,
-				Opcode::Return,
-				Opcode::Else,
-				Opcode::I32Const(1),
-				Opcode::Return,
-				Opcode::End,
-			])),
+		Opcode::If(BlockType::Value(ValueType::I32)),
+			Opcode::GetLocal(0),
+			Opcode::GetLocal(0),
+			Opcode::I32Const(1),
+			Opcode::I32Sub,
+			Opcode::Call(1),
+			Opcode::I32Mul,
+			Opcode::Return,
+		Opcode::Else,
+			Opcode::I32Const(1),
+		Opcode::Return,
+		Opcode::End,
 		Opcode::End,
 	]);
 

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -122,7 +122,6 @@ impl Validator {
 
 	pub fn validate_instruction<'a>(context: &mut FunctionValidationContext, opcode: &'a Opcode) -> Result<InstructionOutcome, Error> {
 		debug!(target: "validator", "validating {:?}", opcode);
-println!("validating {:?} at {}, len: {}", opcode, context.position, context.value_stack.len());
 		match opcode {
 			&Opcode::Unreachable => Ok(InstructionOutcome::Unreachable),
 			&Opcode::Nop => Ok(InstructionOutcome::ValidateNextInstruction),
@@ -644,7 +643,6 @@ impl<'a> FunctionValidationContext<'a> {
 	}
 
 	pub fn push_label(&mut self, frame_type: BlockFrameType, block_type: BlockType) -> Result<(), Error> {
-//println!("=== validating.push_label({})", self.position);
 		self.frame_stack.push(ValidationFrame {
 			frame_type: frame_type,
 			block_type: block_type,
@@ -668,7 +666,6 @@ impl<'a> FunctionValidationContext<'a> {
 			}
 		}
 
-//println!("=== validating.pop_label({}) -> {}. block_type = {:?}. value = {:?}. len: {}", frame.position, self.position, frame.block_type, actual_value_type, self.value_stack.len());
 		match frame.block_type {
 			BlockType::NoResult if actual_value_type.map(|vt| vt.is_any_unlimited()).unwrap_or(true) => (),
 			BlockType::Value(required_value_type) if actual_value_type.map(|vt| vt == required_value_type).unwrap_or(false) => (),

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -114,7 +114,7 @@ impl Validator {
 		}
 	}
 
-	pub fn validate_instruction<'a>(context: &mut FunctionValidationContext, opcode: &'a Opcode) -> Result<InstructionOutcome, Error> {
+	fn validate_instruction<'a>(context: &mut FunctionValidationContext, opcode: &'a Opcode) -> Result<InstructionOutcome, Error> {
 		debug!(target: "validator", "validating {:?}", opcode);
 		match opcode {
 			&Opcode::Unreachable => Ok(InstructionOutcome::Unreachable),

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -94,7 +94,7 @@ impl Validator {
 		Ok(())
 	}
 
-	fn validate_function_block<'a>(context: &mut FunctionValidationContext, body: &[Opcode]) -> Result<(), Error> {
+	fn validate_function_block(context: &mut FunctionValidationContext, body: &[Opcode]) -> Result<(), Error> {
 		let body_len = body.len();
 		if body_len == 0 {
 			return Err(Error::Validation("Non-empty function body expected".into()));
@@ -114,7 +114,7 @@ impl Validator {
 		}
 	}
 
-	fn validate_instruction<'a>(context: &mut FunctionValidationContext, opcode: &'a Opcode) -> Result<InstructionOutcome, Error> {
+	fn validate_instruction(context: &mut FunctionValidationContext, opcode: &Opcode) -> Result<InstructionOutcome, Error> {
 		debug!(target: "validator", "validating {:?}", opcode);
 		match opcode {
 			&Opcode::Unreachable => Ok(InstructionOutcome::Unreachable),
@@ -309,49 +309,49 @@ impl Validator {
 		}
 	}
 
-	fn validate_const<'a>(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_const(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_unop<'a>(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_unop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_binop<'a>(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_binop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_testop<'a>(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_testop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_relop<'a>(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_relop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_cvtop<'a>(context: &mut FunctionValidationContext, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_cvtop(context: &mut FunctionValidationContext, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type1)?;
 		context.push_value(value_type2)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_drop<'a>(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_drop(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
 		context.pop_any_value().map(|_| ())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_select<'a>(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_select(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		let select_type = context.pop_any_value()?;
 		context.pop_value(select_type)?;
@@ -359,13 +359,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_local<'a>(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		context.push_value(local_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_local<'a>(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.pop_any_value()?;
 		if local_type != value_type {
@@ -374,7 +374,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_tee_local<'a>(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_tee_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.tee_any_value()?;
 		if local_type != value_type {
@@ -383,13 +383,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_global<'a>(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_global(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
 		let global_type = context.require_global(index, None)?;
 		context.push_value(global_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_global<'a>(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_global(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
 		let global_type = context.require_global(index, Some(true))?;
 		let value_type = context.pop_any_value()?;
 		if global_type != value_type {
@@ -398,7 +398,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_load<'a>(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_load(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -411,7 +411,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_store<'a>(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_store(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -424,15 +424,15 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_block<'a>(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_block(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.push_label(BlockFrameType::Block, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_loop<'a>(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_loop(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.push_label(BlockFrameType::Loop, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_if<'a>(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_if(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		context.push_label(BlockFrameType::IfTrue, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
@@ -466,7 +466,7 @@ impl Validator {
 		context.pop_label().map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br<'a>(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
 		let (frame_type, frame_block_type) = {
 			let frame = context.require_label(idx)?;
 			(frame.frame_type, frame.block_type)
@@ -480,7 +480,7 @@ impl Validator {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_br_if<'a>(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_if(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		if let BlockType::Value(value_type) = context.require_label(idx)?.block_type {
 			context.tee_value(value_type.into())?;
@@ -488,7 +488,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br_table<'a>(context: &mut FunctionValidationContext, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_table(context: &mut FunctionValidationContext, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error> {
 		let mut required_block_type = None;
 		
 		{
@@ -520,14 +520,14 @@ impl Validator {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_return<'a>(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_return(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
 		if let BlockType::Value(value_type) = context.return_type()? {
 			context.tee_value(value_type.into())?;
 		}
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_call<'a>(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
 		let (argument_types, return_type) = context.require_function(idx)?;
 		for argument_type in argument_types.iter().rev() {
 			context.pop_value((*argument_type).into())?;
@@ -538,7 +538,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_call_indirect<'a>(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call_indirect(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
 		context.require_table(DEFAULT_TABLE_INDEX, VariableType::AnyFunc)?;
 
 		context.pop_value(ValueType::I32.into())?;
@@ -552,13 +552,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_current_memory<'a>(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_current_memory(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_grow_memory<'a>(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_grow_memory(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.pop_value(ValueType::I32.into())?;
 		context.push_value(ValueType::I32.into())?;


### PR DESCRIPTION
The main idea is to store the whole function body as plain instructions array (without nesting Opcodes).
This has resolved the most harmful TODO - https://github.com/NikVolf/parity-wasm/blob/a83527639966e92606ea37c8751d9409259fa5ae/src/interpreter/runner.rs#L153 .
Also validation && runner code is quite simplified + further simplification is possible. However, running is now completely impossible without validation, as validation performs code labeling (matches blocks beginnings with blocks ends).
Next step is to get rid of some clone()-s, which are not mandatory (FunctionType, FunctionLabels).