### PR TITLE
Allow to pass user-defined globals along with user functions to env-native

### DIFF
--- a/spec/src/run.rs
+++ b/spec/src/run.rs
@@ -110,7 +110,7 @@ fn run_action(program: &ProgramInstance, action: &test::Action)
                     elements::Internal::Global(global_index) => Ok(ItemIndex::IndexSpace(global_index)),
                     _ => Err(InterpreterError::Global(format!("Expected to have exported global with name {}", field))),
                 })
-                .and_then(|g| module.global(g, None).map(|g| Some(g.get())))
+                .and_then(|g| module.global(g, None, None).map(|g| Some(g.get())))
         }
     }
 }

--- a/src/interpreter/imports.rs
+++ b/src/interpreter/imports.rs
@@ -151,7 +151,7 @@ impl ModuleImports {
 	pub fn global<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>, import: &ImportEntry, required_type: Option<VariableType>) -> Result<Arc<VariableInstance>, Error> {
 		let (module, export) = self.external_export(externals, import, &required_type.clone().map(|rt| ExportEntryType::Global(rt)).unwrap_or(ExportEntryType::Any))?;
 		if let Internal::Global(external_index) = export {
-			return module.global(ItemIndex::Internal(external_index), required_type);
+			return module.global(ItemIndex::Internal(external_index), required_type, externals);
 		}
 
 		Err(Error::Program(format!("wrong import {} from module {} (expecting global)", import.field(), import.module())))

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -78,6 +78,6 @@ pub use self::module::{ModuleInstance, ModuleInstanceInterface, ItemIndex, Expor
 pub use self::table::TableInstance;
 pub use self::program::ProgramInstance;
 pub use self::value::RuntimeValue;
-pub use self::variable::VariableInstance;
-pub use self::env_native::{env_native_module, UserFunctions, UserFunctionExecutor, UserFunctionDescriptor};
+pub use self::variable::{VariableInstance, VariableType, ExternalVariableValue};
+pub use self::env_native::{env_native_module, UserDefinedElements, UserFunctionExecutor, UserFunctionDescriptor};
 pub use self::env::EnvParams;

--- a/src/interpreter/runner.rs
+++ b/src/interpreter/runner.rs
@@ -477,7 +477,7 @@ impl Interpreter {
 
 	fn run_get_global<'a>(context: &mut FunctionContext, index: u32) -> Result<InstructionOutcome<'a>, Error> {
 		context.module()
-			.global(ItemIndex::IndexSpace(index), None)
+			.global(ItemIndex::IndexSpace(index), None, Some(context.externals))
 			.and_then(|g| context.value_stack_mut().push(g.get()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
@@ -486,7 +486,7 @@ impl Interpreter {
 		context
 			.value_stack_mut()
 			.pop()
-			.and_then(|v| context.module().global(ItemIndex::IndexSpace(index), None).and_then(|g| g.set(v)))
+			.and_then(|v| context.module().global(ItemIndex::IndexSpace(index), None, Some(context.externals)).and_then(|g| g.set(v)))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 


### PR DESCRIPTION
closes #74 

Also added `ExternalVariableValue` trait for variables, which must be updated on read (like current_time, ticks, ...). See `native_env_global` test for details.