### PR TITLE
Custom user errors

### DIFF
--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -2,7 +2,7 @@ extern crate parity_wasm;
 
 use std::env::args;
 
-use parity_wasm::{interpreter, CustomModuleInstanceInterface};
+use parity_wasm::{interpreter, ModuleInstanceInterface};
 
 fn main() {
     let args: Vec<_> = args().collect();
@@ -12,7 +12,7 @@ fn main() {
         return;
     }
 
-    let program = parity_wasm::ProgramInstance::with_env_params(
+    let program = parity_wasm::DefaultProgramInstance::with_env_params(
         interpreter::EnvParams {
             total_stack: 128*1024,
             total_memory: 2*1024*1024,

--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -2,7 +2,7 @@ extern crate parity_wasm;
 
 use std::env::args;
 
-use parity_wasm::{interpreter, ModuleInstanceInterface};
+use parity_wasm::{interpreter, CustomModuleInstanceInterface};
 
 fn main() {
     let args: Vec<_> = args().collect();

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -2,7 +2,7 @@ extern crate parity_wasm;
 
 use std::env::args;
 
-use parity_wasm::{interpreter, ModuleInstanceInterface, RuntimeValue};
+use parity_wasm::{interpreter, CustomModuleInstanceInterface, RuntimeValue};
 use parity_wasm::elements::{Internal, External, Type, FunctionType, ValueType};
 
 

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -2,7 +2,7 @@ extern crate parity_wasm;
 
 use std::env::args;
 
-use parity_wasm::{interpreter, CustomModuleInstanceInterface, RuntimeValue};
+use parity_wasm::{interpreter, ModuleInstanceInterface, RuntimeValue};
 use parity_wasm::elements::{Internal, External, Type, FunctionType, ValueType};
 
 
@@ -15,7 +15,7 @@ fn main() {
     let func_name = &args[2];
     let (_, program_args) = args.split_at(3);
 
-    let program = parity_wasm::ProgramInstance::with_env_params(
+    let program = parity_wasm::DefaultProgramInstance::with_env_params(
         interpreter::EnvParams {
             total_stack: 128*1024,
             total_memory: 2*1024*1024,

--- a/spec/src/run.rs
+++ b/spec/src/run.rs
@@ -14,7 +14,7 @@ use parity_wasm::interpreter::{
     DefaultProgramInstance, DefaultModuleInstance, 
     ItemIndex, ExportEntryType,
     Error as InterpreterError,
-    DummyUserError,
+    DummyError as DummyInterpreterError,
 };
 
 fn spec_test_module() -> elements::Module {
@@ -58,7 +58,7 @@ fn try_deserialize(base_dir: &str, module_path: &str) -> Result<elements::Module
     parity_wasm::deserialize_file(&wasm_path)
 }
 
-fn try_load(base_dir: &str, module_path: &str) -> Result<(), parity_wasm::interpreter::Error<DummyUserError>> {
+fn try_load(base_dir: &str, module_path: &str) -> Result<(), DummyInterpreterError> {
     let module = try_deserialize(base_dir, module_path).map_err(|e| parity_wasm::interpreter::Error::Program(format!("{:?}", e)))?;
     let program = DefaultProgramInstance::new().expect("Failed creating program");
     program.add_module("try_load", module, None).map(|_| ())
@@ -91,7 +91,7 @@ fn runtime_values(test_vals: &[test::RuntimeValue]) -> Vec<parity_wasm::RuntimeV
 }
 
 fn run_action(program: &DefaultProgramInstance, action: &test::Action) 
-    -> Result<Option<parity_wasm::RuntimeValue>, InterpreterError<DummyUserError>> 
+    -> Result<Option<parity_wasm::RuntimeValue>, DummyInterpreterError> 
 {
     match *action {
         test::Action::Invoke { ref module, ref field, ref args } => {

--- a/spec/src/run.rs
+++ b/spec/src/run.rs
@@ -14,7 +14,7 @@ use parity_wasm::interpreter::{
     DefaultProgramInstance, DefaultModuleInstance, 
     ItemIndex, ExportEntryType,
     Error as InterpreterError,
-    DummyCustomUserError,
+    DummyUserError,
 };
 
 fn spec_test_module() -> elements::Module {
@@ -58,7 +58,7 @@ fn try_deserialize(base_dir: &str, module_path: &str) -> Result<elements::Module
     parity_wasm::deserialize_file(&wasm_path)
 }
 
-fn try_load(base_dir: &str, module_path: &str) -> Result<(), parity_wasm::interpreter::Error<DummyCustomUserError>> {
+fn try_load(base_dir: &str, module_path: &str) -> Result<(), parity_wasm::interpreter::Error<DummyUserError>> {
     let module = try_deserialize(base_dir, module_path).map_err(|e| parity_wasm::interpreter::Error::Program(format!("{:?}", e)))?;
     let program = DefaultProgramInstance::new().expect("Failed creating program");
     program.add_module("try_load", module, None).map(|_| ())
@@ -91,7 +91,7 @@ fn runtime_values(test_vals: &[test::RuntimeValue]) -> Vec<parity_wasm::RuntimeV
 }
 
 fn run_action(program: &DefaultProgramInstance, action: &test::Action) 
-    -> Result<Option<parity_wasm::RuntimeValue>, InterpreterError<DummyCustomUserError>> 
+    -> Result<Option<parity_wasm::RuntimeValue>, InterpreterError<DummyUserError>> 
 {
     match *action {
         test::Action::Invoke { ref module, ref field, ref args } => {

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use builder::module;
 use elements::{Module, ExportEntry, Internal, GlobalEntry, GlobalType,
 	ValueType, InitExpr, Opcode, Opcodes};
-use interpreter::Error;
+use interpreter::{Error, CustomUserError, InterpreterError};
 use interpreter::env_native::NATIVE_INDEX_FUNC_MIN;
 use interpreter::module::{ModuleInstanceInterface, ModuleInstance, ExecutionParams,
 	ItemIndex, CallerContext, ExportEntryType, InternalFunctionReference, InternalFunction, FunctionSignature};
@@ -78,12 +78,12 @@ pub struct EnvParams {
 	pub allow_memory_growth: bool,
 }
 
-pub struct EnvModuleInstance {
+pub struct EnvModuleInstance<E: CustomUserError> {
 	_params: EnvParams,
-	instance: ModuleInstance,
+	instance: ModuleInstance<E>,
 }
 
-impl EnvModuleInstance {
+impl<E> EnvModuleInstance<E> where E: CustomUserError {
 	pub fn new(params: EnvParams, module: Module) -> Result<Self, Error> {
 		let mut instance = ModuleInstance::new(Weak::default(), "env".into(), module)?;
 		instance.instantiate(None)?;
@@ -95,12 +95,12 @@ impl EnvModuleInstance {
 	}
 }
 
-impl ModuleInstanceInterface for EnvModuleInstance {
-	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
+impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: CustomUserError {
+	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		self.instance.execute_index(index, params)
 	}
 
-	fn execute_export(&self, name: &str, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
+	fn execute_export(&self, name: &str, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		self.instance.execute_export(name, params)
 	}
 
@@ -116,7 +116,7 @@ impl ModuleInstanceInterface for EnvModuleInstance {
 		self.instance.memory(index)
 	}
 
-	fn global<'a>(&self, index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<Arc<VariableInstance>, Error> {
+	fn global<'a>(&self, index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<Arc<VariableInstance>, Error> {
 		self.instance.global(index, variable_type, externals)
 	}
 
@@ -128,11 +128,11 @@ impl ModuleInstanceInterface for EnvModuleInstance {
 		self.instance.function_type_by_index(type_index)
 	}
 
-	fn function_reference<'a>(&self, index: ItemIndex, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<InternalFunctionReference<'a>, Error> {
+	fn function_reference<'a>(&self, index: ItemIndex, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error> {
 		self.instance.function_reference(index, externals)
 	}
 
-	fn function_reference_indirect<'a>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>) -> Result<InternalFunctionReference<'a>, Error> {
+	fn function_reference_indirect<'a>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error> {
 		self.instance.function_reference_indirect(table_idx, type_idx, func_idx, externals)
 	}
 
@@ -140,12 +140,13 @@ impl ModuleInstanceInterface for EnvModuleInstance {
 		Ok(None)
 	}
 
-	fn call_internal_function(&self, outer: CallerContext, index: u32) -> Result<Option<RuntimeValue>, Error> {
+	fn call_internal_function(&self, outer: CallerContext<E>, index: u32) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		// to make interpreter independent of *SCRIPTEN runtime, just make abort/assert = interpreter Error
 		match index {
 			INDEX_FUNC_ABORT => self.global(ItemIndex::IndexSpace(INDEX_GLOBAL_ABORT), Some(VariableType::I32), None)
 				.and_then(|g| g.set(RuntimeValue::I32(1)))
-				.and_then(|_| Err(Error::Trap("abort".into()))),
+				.and_then(|_| Err(Error::Trap("abort".into())))
+				.map_err(Into::into),
 			INDEX_FUNC_ASSERT => outer.value_stack.pop_as::<i32>()
 				.and_then(|condition| if condition == 0 {
 					self.global(ItemIndex::IndexSpace(INDEX_GLOBAL_ABORT), Some(VariableType::I32), None)
@@ -153,18 +154,20 @@ impl ModuleInstanceInterface for EnvModuleInstance {
 						.and_then(|_| Err(Error::Trap("assertion failed".into())))
 				} else {
 					Ok(None)
-				}),
+				})
+				.map_err(Into::into),
 			INDEX_FUNC_ENLARGE_MEMORY => Ok(Some(RuntimeValue::I32(0))), // TODO: support memory enlarge
 			INDEX_FUNC_GET_TOTAL_MEMORY => self.global(ItemIndex::IndexSpace(INDEX_GLOBAL_TOTAL_MEMORY), Some(VariableType::I32), None)
 				.map(|g| g.get())
-				.map(Some),
-			INDEX_FUNC_MIN_NONUSED ... INDEX_FUNC_MAX => Err(Error::Trap("unimplemented".into())),
-			_ => Err(Error::Trap(format!("trying to call function with index {} in env module", index))),
+				.map(Some)
+				.map_err(Into::into),
+			INDEX_FUNC_MIN_NONUSED ... INDEX_FUNC_MAX => Err(Error::Trap("unimplemented".into()).into()),
+			_ => Err(Error::Trap(format!("trying to call function with index {} in env module", index)).into()),
 		}
 	}
 }
 
-pub fn env_module(params: EnvParams) -> Result<EnvModuleInstance, Error> {
+pub fn env_module<E: CustomUserError>(params: EnvParams) -> Result<EnvModuleInstance<E>, Error> {
 	debug_assert!(params.total_stack < params.total_memory);
 	debug_assert!((params.total_stack % LINEAR_MEMORY_PAGE_SIZE) == 0);
 	debug_assert!((params.total_memory % LINEAR_MEMORY_PAGE_SIZE) == 0);

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use builder::module;
 use elements::{Module, ExportEntry, Internal, GlobalEntry, GlobalType,
 	ValueType, InitExpr, Opcode, Opcodes};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::env_native::NATIVE_INDEX_FUNC_MIN;
 use interpreter::module::{ModuleInstanceInterface, ModuleInstance, ExecutionParams,
 	ItemIndex, CallerContext, ExportEntryType, InternalFunctionReference, InternalFunction, FunctionSignature};
@@ -78,12 +78,12 @@ pub struct EnvParams {
 	pub allow_memory_growth: bool,
 }
 
-pub struct EnvModuleInstance<E: CustomUserError> {
+pub struct EnvModuleInstance<E: UserError> {
 	_params: EnvParams,
 	instance: ModuleInstance<E>,
 }
 
-impl<E> EnvModuleInstance<E> where E: CustomUserError {
+impl<E> EnvModuleInstance<E> where E: UserError {
 	pub fn new(params: EnvParams, module: Module) -> Result<Self, Error<E>> {
 		let mut instance = ModuleInstance::new(Weak::default(), "env".into(), module)?;
 		instance.instantiate(None)?;
@@ -95,7 +95,7 @@ impl<E> EnvModuleInstance<E> where E: CustomUserError {
 	}
 }
 
-impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: CustomUserError {
+impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: UserError {
 	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, Error<E>> {
 		self.instance.execute_index(index, params)
 	}
@@ -167,7 +167,7 @@ impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: CustomUserE
 	}
 }
 
-pub fn env_module<E: CustomUserError>(params: EnvParams) -> Result<EnvModuleInstance<E>, Error<E>> {
+pub fn env_module<E: UserError>(params: EnvParams) -> Result<EnvModuleInstance<E>, Error<E>> {
 	debug_assert!(params.total_stack < params.total_memory);
 	debug_assert!((params.total_stack % LINEAR_MEMORY_PAGE_SIZE) == 0);
 	debug_assert!((params.total_memory % LINEAR_MEMORY_PAGE_SIZE) == 0);

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use builder::module;
 use elements::{Module, ExportEntry, Internal, GlobalEntry, GlobalType,
 	ValueType, InitExpr, Opcode, Opcodes};
-use interpreter::{Error, CustomUserError, InterpreterError};
+use interpreter::{Error, CustomUserError};
 use interpreter::env_native::NATIVE_INDEX_FUNC_MIN;
 use interpreter::module::{ModuleInstanceInterface, ModuleInstance, ExecutionParams,
 	ItemIndex, CallerContext, ExportEntryType, InternalFunctionReference, InternalFunction, FunctionSignature};
@@ -84,7 +84,7 @@ pub struct EnvModuleInstance<E: CustomUserError> {
 }
 
 impl<E> EnvModuleInstance<E> where E: CustomUserError {
-	pub fn new(params: EnvParams, module: Module) -> Result<Self, Error> {
+	pub fn new(params: EnvParams, module: Module) -> Result<Self, Error<E>> {
 		let mut instance = ModuleInstance::new(Weak::default(), "env".into(), module)?;
 		instance.instantiate(None)?;
 
@@ -96,51 +96,51 @@ impl<E> EnvModuleInstance<E> where E: CustomUserError {
 }
 
 impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: CustomUserError {
-	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
+	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, Error<E>> {
 		self.instance.execute_index(index, params)
 	}
 
-	fn execute_export(&self, name: &str, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
+	fn execute_export(&self, name: &str, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, Error<E>> {
 		self.instance.execute_export(name, params)
 	}
 
-	fn export_entry<'a>(&self, name: &str, required_type: &ExportEntryType) -> Result<Internal, Error> {
+	fn export_entry<'a>(&self, name: &str, required_type: &ExportEntryType) -> Result<Internal, Error<E>> {
 		self.instance.export_entry(name, required_type)
 	}
 
-	fn table(&self, index: ItemIndex) -> Result<Arc<TableInstance>, Error> {
+	fn table(&self, index: ItemIndex) -> Result<Arc<TableInstance<E>>, Error<E>> {
 		self.instance.table(index)
 	}
 
-	fn memory(&self, index: ItemIndex) -> Result<Arc<MemoryInstance>, Error> {
+	fn memory(&self, index: ItemIndex) -> Result<Arc<MemoryInstance<E>>, Error<E>> {
 		self.instance.memory(index)
 	}
 
-	fn global<'a>(&self, index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<Arc<VariableInstance>, Error> {
+	fn global<'a>(&self, index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<Arc<VariableInstance<E>>, Error<E>> {
 		self.instance.global(index, variable_type, externals)
 	}
 
-	fn function_type(&self, function_index: ItemIndex) -> Result<FunctionSignature, Error> {
+	fn function_type(&self, function_index: ItemIndex) -> Result<FunctionSignature, Error<E>> {
 		self.instance.function_type(function_index)
 	}
 
-	fn function_type_by_index(&self, type_index: u32) -> Result<FunctionSignature, Error> {
+	fn function_type_by_index(&self, type_index: u32) -> Result<FunctionSignature, Error<E>> {
 		self.instance.function_type_by_index(type_index)
 	}
 
-	fn function_reference<'a>(&self, index: ItemIndex, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error> {
+	fn function_reference<'a>(&self, index: ItemIndex, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error<E>> {
 		self.instance.function_reference(index, externals)
 	}
 
-	fn function_reference_indirect<'a>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error> {
+	fn function_reference_indirect<'a>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>) -> Result<InternalFunctionReference<'a, E>, Error<E>> {
 		self.instance.function_reference_indirect(table_idx, type_idx, func_idx, externals)
 	}
 
-	fn function_body<'a>(&'a self, _internal_index: u32) -> Result<Option<InternalFunction<'a>>, Error> {
+	fn function_body<'a>(&'a self, _internal_index: u32) -> Result<Option<InternalFunction<'a>>, Error<E>> {
 		Ok(None)
 	}
 
-	fn call_internal_function(&self, outer: CallerContext<E>, index: u32) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
+	fn call_internal_function(&self, outer: CallerContext<E>, index: u32) -> Result<Option<RuntimeValue>, Error<E>> {
 		// to make interpreter independent of *SCRIPTEN runtime, just make abort/assert = interpreter Error
 		match index {
 			INDEX_FUNC_ABORT => self.global(ItemIndex::IndexSpace(INDEX_GLOBAL_ABORT), Some(VariableType::I32), None)
@@ -167,7 +167,7 @@ impl<E> ModuleInstanceInterface<E> for EnvModuleInstance<E> where E: CustomUserE
 	}
 }
 
-pub fn env_module<E: CustomUserError>(params: EnvParams) -> Result<EnvModuleInstance<E>, Error> {
+pub fn env_module<E: CustomUserError>(params: EnvParams) -> Result<EnvModuleInstance<E>, Error<E>> {
 	debug_assert!(params.total_stack < params.total_memory);
 	debug_assert!((params.total_stack % LINEAR_MEMORY_PAGE_SIZE) == 0);
 	debug_assert!((params.total_memory % LINEAR_MEMORY_PAGE_SIZE) == 0);

--- a/src/interpreter/env_native.rs
+++ b/src/interpreter/env_native.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::borrow::Cow;
 use parking_lot::RwLock;
 use elements::{Internal, ValueType};
-use interpreter::Error;
+use interpreter::{Error, CustomUserError, InterpreterError};
 use interpreter::module::{ModuleInstanceInterface, ExecutionParams, ItemIndex,
 	CallerContext, ExportEntryType, InternalFunctionReference, InternalFunction, FunctionSignature};
 use interpreter::memory::MemoryInstance;
@@ -17,9 +17,9 @@ pub const NATIVE_INDEX_FUNC_MIN: u32 = 10001;
 pub const NATIVE_INDEX_GLOBAL_MIN: u32 = 20001;
 
 /// User functions executor.
-pub trait UserFunctionExecutor {
+pub trait UserFunctionExecutor<E: CustomUserError> {
 	/// Execute function with given name.
-	fn execute(&mut self, name: &str, context: CallerContext) -> Result<Option<RuntimeValue>, Error>;
+	fn execute(&mut self, name: &str, context: CallerContext<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>>;
 }
 
 /// User function descriptor
@@ -68,21 +68,21 @@ impl UserFunctionDescriptor {
 }
 
 /// Set of user-defined module elements.
-pub struct UserDefinedElements<'a> {
+pub struct UserDefinedElements<'a, E: 'a + CustomUserError> {
 	/// User globals list.
 	pub globals: HashMap<String, Arc<VariableInstance>>,
 	/// User functions list.
 	pub functions: Cow<'static, [UserFunctionDescriptor]>,
 	/// Functions executor.
-	pub executor: Option<&'a mut UserFunctionExecutor>,
+	pub executor: Option<&'a mut UserFunctionExecutor<E>>,
 }
 
 /// Native module instance.
-pub struct NativeModuleInstance<'a> {
+pub struct NativeModuleInstance<'a, E: 'a + CustomUserError> {
 	/// Underllying module reference.
-	env: Arc<ModuleInstanceInterface>,
+	env: Arc<ModuleInstanceInterface<E>>,
 	/// User function executor.
-	executor: RwLock<Option<&'a mut UserFunctionExecutor>>,
+	executor: RwLock<Option<&'a mut UserFunctionExecutor<E>>>,
 	/// By-name functions index.
 	functions_by_name: HashMap<String, u32>,
 	/// User functions list.
@@ -93,9 +93,9 @@ pub struct NativeModuleInstance<'a> {
 	globals: Vec<Arc<VariableInstance>>,
 }
 
-impl<'a> NativeModuleInstance<'a> {
+impl<'a, E> NativeModuleInstance<'a, E> where E: CustomUserError {
 	/// Create new native module
-	pub fn new(env: Arc<ModuleInstanceInterface>, elements: UserDefinedElements<'a>) -> Result<Self, Error> {
+	pub fn new(env: Arc<ModuleInstanceInterface<E>>, elements: UserDefinedElements<'a, E>) -> Result<Self, Error> {
 		if !elements.functions.is_empty() && elements.executor.is_none() {
 			return Err(Error::Function("trying to construct native env module with functions, but without executor".into()));
 		}
@@ -111,12 +111,12 @@ impl<'a> NativeModuleInstance<'a> {
 	}
 }
 
-impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
-	fn execute_index(&self, index: u32, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
+impl<'a, E> ModuleInstanceInterface<E> for NativeModuleInstance<'a, E> where E: CustomUserError {
+	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		self.env.execute_index(index, params)
 	}
 
-	fn execute_export(&self, name: &str, params: ExecutionParams) -> Result<Option<RuntimeValue>, Error> {
+	fn execute_export(&self, name: &str, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		self.env.execute_export(name, params)
 	}
 
@@ -155,7 +155,7 @@ impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
 		self.env.memory(index)
 	}
 
-	fn global<'b>(&self, global_index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<Arc<VariableInstance>, Error> {
+	fn global<'b>(&self, global_index: ItemIndex, variable_type: Option<VariableType>, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface<E> + 'b>>>) -> Result<Arc<VariableInstance>, Error> {
 		let index = match global_index {
 			ItemIndex::IndexSpace(index) | ItemIndex::Internal(index) => index,
 			ItemIndex::External(_) => unreachable!("trying to get global, exported by native env module"),
@@ -190,11 +190,11 @@ impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
 		self.function_type(ItemIndex::Internal(type_index))
 	}
 
-	fn function_reference<'b>(&self, index: ItemIndex, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<InternalFunctionReference<'b>, Error> {
+	fn function_reference<'b>(&self, index: ItemIndex, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface<E> + 'b>>>) -> Result<InternalFunctionReference<'b, E>, Error> {
 		self.env.function_reference(index, externals)
 	}
 
-	fn function_reference_indirect<'b>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface + 'b>>>) -> Result<InternalFunctionReference<'b>, Error> {
+	fn function_reference_indirect<'b>(&self, table_idx: u32, type_idx: u32, func_idx: u32, externals: Option<&'b HashMap<String, Arc<ModuleInstanceInterface<E> + 'b>>>) -> Result<InternalFunctionReference<'b, E>, Error> {
 		self.env.function_reference_indirect(table_idx, type_idx, func_idx, externals)
 	}
 
@@ -202,14 +202,14 @@ impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
 		Ok(None)
 	}
 
-	fn call_internal_function(&self, outer: CallerContext, index: u32) -> Result<Option<RuntimeValue>, Error> {
+	fn call_internal_function(&self, outer: CallerContext<E>, index: u32) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
 		if index < NATIVE_INDEX_FUNC_MIN || index >= NATIVE_INDEX_GLOBAL_MIN {
 			return self.env.call_internal_function(outer, index);
 		}
 
 		self.functions
 			.get((index - NATIVE_INDEX_FUNC_MIN) as usize)
-			.ok_or(Error::Native(format!("trying to call native function with index {}", index)))
+			.ok_or(Error::Native(format!("trying to call native function with index {}", index)).into())
 			.and_then(|f| self.executor.write()
 				.as_mut()
 				.expect("function existss; if function exists, executor must also exists [checked in constructor]; qed")
@@ -218,7 +218,7 @@ impl<'a> ModuleInstanceInterface for NativeModuleInstance<'a> {
 }
 
 /// Create wrapper for env module with given native user functions.
-pub fn env_native_module<'a>(env: Arc<ModuleInstanceInterface>, user_elements: UserDefinedElements<'a>) -> Result<NativeModuleInstance, Error> {
+pub fn env_native_module<'a, E: CustomUserError>(env: Arc<ModuleInstanceInterface<E>>, user_elements: UserDefinedElements<'a, E>) -> Result<NativeModuleInstance<E>, Error> {
 	NativeModuleInstance::new(env, user_elements)
 }
 

--- a/src/interpreter/env_native.rs
+++ b/src/interpreter/env_native.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::borrow::Cow;
 use parking_lot::RwLock;
 use elements::{Internal, ValueType};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::module::{ModuleInstanceInterface, ExecutionParams, ItemIndex,
 	CallerContext, ExportEntryType, InternalFunctionReference, InternalFunction, FunctionSignature};
 use interpreter::memory::MemoryInstance;
@@ -17,7 +17,7 @@ pub const NATIVE_INDEX_FUNC_MIN: u32 = 10001;
 pub const NATIVE_INDEX_GLOBAL_MIN: u32 = 20001;
 
 /// User functions executor.
-pub trait UserFunctionExecutor<E: CustomUserError> {
+pub trait UserFunctionExecutor<E: UserError> {
 	/// Execute function with given name.
 	fn execute(&mut self, name: &str, context: CallerContext<E>) -> Result<Option<RuntimeValue>, Error<E>>;
 }
@@ -68,7 +68,7 @@ impl UserFunctionDescriptor {
 }
 
 /// Set of user-defined module elements.
-pub struct UserDefinedElements<'a, E: 'a + CustomUserError> {
+pub struct UserDefinedElements<'a, E: 'a + UserError> {
 	/// User globals list.
 	pub globals: HashMap<String, Arc<VariableInstance<E>>>,
 	/// User functions list.
@@ -78,7 +78,7 @@ pub struct UserDefinedElements<'a, E: 'a + CustomUserError> {
 }
 
 /// Native module instance.
-pub struct NativeModuleInstance<'a, E: 'a + CustomUserError> {
+pub struct NativeModuleInstance<'a, E: 'a + UserError> {
 	/// Underllying module reference.
 	env: Arc<ModuleInstanceInterface<E>>,
 	/// User function executor.
@@ -93,7 +93,7 @@ pub struct NativeModuleInstance<'a, E: 'a + CustomUserError> {
 	globals: Vec<Arc<VariableInstance<E>>>,
 }
 
-impl<'a, E> NativeModuleInstance<'a, E> where E: CustomUserError {
+impl<'a, E> NativeModuleInstance<'a, E> where E: UserError {
 	/// Create new native module
 	pub fn new(env: Arc<ModuleInstanceInterface<E>>, elements: UserDefinedElements<'a, E>) -> Result<Self, Error<E>> {
 		if !elements.functions.is_empty() && elements.executor.is_none() {
@@ -111,7 +111,7 @@ impl<'a, E> NativeModuleInstance<'a, E> where E: CustomUserError {
 	}
 }
 
-impl<'a, E> ModuleInstanceInterface<E> for NativeModuleInstance<'a, E> where E: CustomUserError {
+impl<'a, E> ModuleInstanceInterface<E> for NativeModuleInstance<'a, E> where E: UserError {
 	fn execute_index(&self, index: u32, params: ExecutionParams<E>) -> Result<Option<RuntimeValue>, Error<E>> {
 		self.env.execute_index(index, params)
 	}
@@ -218,7 +218,7 @@ impl<'a, E> ModuleInstanceInterface<E> for NativeModuleInstance<'a, E> where E: 
 }
 
 /// Create wrapper for env module with given native user functions.
-pub fn env_native_module<'a, E: CustomUserError>(env: Arc<ModuleInstanceInterface<E>>, user_elements: UserDefinedElements<'a, E>) -> Result<NativeModuleInstance<E>, Error<E>> {
+pub fn env_native_module<'a, E: UserError>(env: Arc<ModuleInstanceInterface<E>>, user_elements: UserDefinedElements<'a, E>) -> Result<NativeModuleInstance<E>, Error<E>> {
 	NativeModuleInstance::new(env, user_elements)
 }
 

--- a/src/interpreter/imports.rs
+++ b/src/interpreter/imports.rs
@@ -104,7 +104,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 	}
 
 	/// Get module reference.
-	pub fn module<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, name: &str) -> Result<Arc<ModuleInstanceInterface<E> + 'a>, Error> {
+	pub fn module<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, name: &str) -> Result<Arc<ModuleInstanceInterface<E> + 'a>, Error<E>> {
 		if let Some(externals) = externals {
 			if let Some(module) = externals.get(name).cloned() {
 				return Ok(module);
@@ -118,7 +118,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 	}
 
 	/// Get function index.
-	pub fn function<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: Option<FunctionSignature>) -> Result<u32, Error> {
+	pub fn function<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: Option<FunctionSignature>) -> Result<u32, Error<E>> {
 		let (_, export) = self.external_export(externals, import, &required_type.map(|ft| ExportEntryType::Function(ft)).unwrap_or(ExportEntryType::Any))?;
 		if let Internal::Function(external_index) = export {
 			return Ok(external_index);
@@ -128,7 +128,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 	}
 
 	/// Get table reference.
-	pub fn table<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry) -> Result<Arc<TableInstance>, Error> {
+	pub fn table<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry) -> Result<Arc<TableInstance<E>>, Error<E>> {
 		let (module, export) = self.external_export(externals, import, &ExportEntryType::Any)?;
 		if let Internal::Table(external_index) = export {
 			return module.table(ItemIndex::Internal(external_index));
@@ -138,7 +138,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 	}
 
 	/// Get memory reference.
-	pub fn memory<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry) -> Result<Arc<MemoryInstance>, Error> {
+	pub fn memory<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry) -> Result<Arc<MemoryInstance<E>>, Error<E>> {
 		let (module, export) = self.external_export(externals, import, &ExportEntryType::Any)?;
 		if let Internal::Memory(external_index) = export {
 			return module.memory(ItemIndex::Internal(external_index));
@@ -148,7 +148,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 	}
 
 	/// Get global reference.
-	pub fn global<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: Option<VariableType>) -> Result<Arc<VariableInstance>, Error> {
+	pub fn global<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: Option<VariableType>) -> Result<Arc<VariableInstance<E>>, Error<E>> {
 		let (module, export) = self.external_export(externals, import, &required_type.clone().map(|rt| ExportEntryType::Global(rt)).unwrap_or(ExportEntryType::Any))?;
 		if let Internal::Global(external_index) = export {
 			return module.global(ItemIndex::Internal(external_index), required_type, externals);
@@ -157,7 +157,7 @@ impl<E> ModuleImports<E> where E: CustomUserError {
 		Err(Error::Program(format!("wrong import {} from module {} (expecting global)", import.field(), import.module())))
 	}
 
-	fn external_export<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: &ExportEntryType) -> Result<(Arc<ModuleInstanceInterface<E> + 'a>, Internal), Error> {
+	fn external_export<'a>(&self, externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>, import: &ImportEntry, required_type: &ExportEntryType) -> Result<(Arc<ModuleInstanceInterface<E> + 'a>, Internal), Error<E>> {
 		self.module(externals, import.module())
 			.and_then(|m|
 				m.export_entry(import.field(), required_type)

--- a/src/interpreter/imports.rs
+++ b/src/interpreter/imports.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Weak};
 use std::collections::HashMap;
 use elements::{ImportSection, ImportEntry, External, Internal};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::memory::MemoryInstance;
 use interpreter::module::{ModuleInstanceInterface, ItemIndex, ExportEntryType, FunctionSignature};
 use interpreter::program::ProgramInstanceEssence;
@@ -9,7 +9,7 @@ use interpreter::table::TableInstance;
 use interpreter::variable::{VariableInstance, VariableType};
 
 /// Module imports.
-pub struct ModuleImports<E: CustomUserError> {
+pub struct ModuleImports<E: UserError> {
 	/// Program instance.
 	program: Weak<ProgramInstanceEssence<E>>,
 	/// External functions.
@@ -22,7 +22,7 @@ pub struct ModuleImports<E: CustomUserError> {
 	globals: Vec<usize>,
 }
 
-impl<E> ModuleImports<E> where E: CustomUserError {
+impl<E> ModuleImports<E> where E: UserError {
 	/// Create new imports for given import section.
 	pub fn new(program: Weak<ProgramInstanceEssence<E>>, import_section: Option<&ImportSection>) -> Self {
 		let mut functions = Vec::new();

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -2,7 +2,7 @@ use std::u32;
 use std::sync::Arc;
 use parking_lot::RwLock;
 use elements::MemoryType;
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::module::check_limits;
 
 /// Linear memory page size.
@@ -11,7 +11,7 @@ pub const LINEAR_MEMORY_PAGE_SIZE: u32 = 65536;
 const LINEAR_MEMORY_MAX_PAGES: u32 = 65536;
 
 /// Linear memory instance.
-pub struct MemoryInstance<E: CustomUserError> {
+pub struct MemoryInstance<E: UserError> {
 	/// Linear memory buffer.
 	buffer: RwLock<Vec<u8>>,
 	/// Maximum buffer size.
@@ -36,7 +36,7 @@ impl<'a, B: 'a> CheckedRegion<'a, B> where B: ::std::ops::Deref<Target=Vec<u8>> 
 	}
 }
 
-impl<E> MemoryInstance<E> where E: CustomUserError {
+impl<E> MemoryInstance<E> where E: UserError {
 	/// Create new linear memory instance.
 	pub fn new(memory_type: &MemoryType) -> Result<Arc<Self>, Error<E>> {
 		check_limits(memory_type.limits())?;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,12 +1,12 @@
 //! WebAssembly interpreter module.
 
 /// Custom user error.
-pub trait CustomUserError: 'static + ::std::fmt::Display + ::std::fmt::Debug + Clone + PartialEq {
+pub trait UserError: 'static + ::std::fmt::Display + ::std::fmt::Debug + Clone + PartialEq {
 }
 
 /// Internal interpreter error.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Error<E> where E: CustomUserError {
+pub enum Error<E> where E: UserError {
 	/// Program-level error.
 	Program(String),
 	/// Validation error.
@@ -41,7 +41,7 @@ pub enum Error<E> where E: CustomUserError {
 	User(E),
 }
 
-impl<E> Into<String> for Error<E> where E: CustomUserError {
+impl<E> Into<String> for Error<E> where E: UserError {
 	fn into(self) -> String {
 		match self {
 			Error::Program(s) => s,
@@ -66,11 +66,11 @@ impl<E> Into<String> for Error<E> where E: CustomUserError {
 
 /// Dummy user error.
 #[derive(Debug, Clone, PartialEq)]
-pub struct DummyCustomUserError;
+pub struct DummyUserError;
 
-impl CustomUserError for DummyCustomUserError {}
+impl UserError for DummyUserError {}
 
-impl ::std::fmt::Display for DummyCustomUserError {
+impl ::std::fmt::Display for DummyUserError {
 	fn fmt(&self, _f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> { Ok(()) }
 }
 
@@ -102,12 +102,12 @@ pub use self::env::EnvParams;
 
 /// Default type of ProgramInstance if you do not need any custom user errors.
 /// To work with custom user errors or interpreter internals, use CustomProgramInstance.
-pub type DefaultProgramInstance = self::program::ProgramInstance<DummyCustomUserError>;
+pub type DefaultProgramInstance = self::program::ProgramInstance<DummyUserError>;
 
 /// Default type of ModuleInstance if you do not need any custom user errors.
 /// To work with custom user errors or interpreter internals, use CustomModuleInstance.
-pub type DefaultModuleInstance = self::module::ModuleInstance<DummyCustomUserError>;
+pub type DefaultModuleInstance = self::module::ModuleInstance<DummyUserError>;
 
 /// Default type of ModuleInstanceInterface if you do not need any custom user errors.
 /// To work with custom user errors or interpreter internals, use CustomModuleInstanceInterface.
-pub type DefaultModuleInstanceInterface = self::module::ModuleInstanceInterface<DummyCustomUserError>;
+pub type DefaultModuleInstanceInterface = self::module::ModuleInstanceInterface<DummyUserError>;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -100,6 +100,9 @@ pub use self::variable::{VariableInstance, VariableType, ExternalVariableValue};
 pub use self::env_native::{env_native_module, UserDefinedElements, UserFunctionExecutor, UserFunctionDescriptor};
 pub use self::env::EnvParams;
 
+/// Default type of Error if you do not need any custom user errors.
+pub type DummyError = Error<DummyUserError>;
+
 /// Default type of ProgramInstance if you do not need any custom user errors.
 /// To work with custom user errors or interpreter internals, use CustomProgramInstance.
 pub type DefaultProgramInstance = self::program::ProgramInstance<DummyUserError>;

--- a/src/interpreter/program.rs
+++ b/src/interpreter/program.rs
@@ -2,23 +2,23 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use parking_lot::RwLock;
 use elements::Module;
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::env::{self, env_module};
 use interpreter::module::{ModuleInstance, ModuleInstanceInterface};
 
 /// Program instance. Program is a set of instantiated modules.
-pub struct ProgramInstance<E: CustomUserError> {
+pub struct ProgramInstance<E: UserError> {
 	/// Shared data reference.
 	essence: Arc<ProgramInstanceEssence<E>>,
 }
 
 /// Program instance essence.
-pub struct ProgramInstanceEssence<E: CustomUserError> {
+pub struct ProgramInstanceEssence<E: UserError> {
 	/// Loaded modules.
 	modules: RwLock<HashMap<String, Arc<ModuleInstanceInterface<E>>>>,
 }
 
-impl<E> ProgramInstance<E> where E: CustomUserError {
+impl<E> ProgramInstance<E> where E: UserError {
 	/// Create new program instance.
 	pub fn new() -> Result<Self, Error<E>> {
 		ProgramInstance::with_env_params(env::EnvParams::default())
@@ -55,7 +55,7 @@ impl<E> ProgramInstance<E> where E: CustomUserError {
 	}
 }
 
-impl<E> ProgramInstanceEssence<E> where E: CustomUserError {
+impl<E> ProgramInstanceEssence<E> where E: UserError {
 	/// Create new program essence.
 	pub fn new() -> Result<Self, Error<E>> {
 		ProgramInstanceEssence::with_env_params(env::EnvParams::default())

--- a/src/interpreter/runner.rs
+++ b/src/interpreter/runner.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Display};
 use std::iter::repeat;
 use std::collections::{HashMap, VecDeque};
 use elements::{Opcode, BlockType, Local};
-use interpreter::{Error, CustomUserError, InterpreterError};
+use interpreter::{Error, CustomUserError};
 use interpreter::module::{ModuleInstanceInterface, CallerContext, ItemIndex, InternalFunctionReference, FunctionSignature};
 use interpreter::stack::StackWithLimit;
 use interpreter::value::{
@@ -37,11 +37,11 @@ pub struct FunctionContext<'a, E: 'a + CustomUserError> {
 	/// Function return type.
 	pub return_type: BlockType,
 	/// Local variables.
-	pub locals: Vec<VariableInstance>,
+	pub locals: Vec<VariableInstance<E>>,
 	/// Values stack.
-	pub value_stack: StackWithLimit<RuntimeValue>,
+	pub value_stack: StackWithLimit<RuntimeValue, E>,
 	/// Blocks frames stack.
-	pub frame_stack: StackWithLimit<BlockFrame>,
+	pub frame_stack: StackWithLimit<BlockFrame, E>,
 	/// Current instruction position.
 	pub position: usize,
 }
@@ -70,7 +70,7 @@ enum RunResult<'a, E: 'a + CustomUserError> {
 }
 
 impl<E> Interpreter<E> where E: CustomUserError {
-	pub fn run_function(function_context: FunctionContext<E>) -> Result<Option<RuntimeValue>, InterpreterError<E>> {
+	pub fn run_function(function_context: FunctionContext<E>) -> Result<Option<RuntimeValue>, Error<E>> {
 		let mut function_stack = VecDeque::new();
 		function_stack.push_back(function_context);
 
@@ -120,7 +120,7 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		}
 	}
 
-	fn do_run_function<'a>(function_context: &mut FunctionContext<'a, E>, function_body: &[Opcode], function_labels: &HashMap<usize, usize>) -> Result<RunResult<'a, E>, Error> {
+	fn do_run_function<'a>(function_context: &mut FunctionContext<'a, E>, function_body: &[Opcode], function_labels: &HashMap<usize, usize>) -> Result<RunResult<'a, E>, Error<E>> {
 		loop {
 			let instruction = &function_body[function_context.position];
 
@@ -158,7 +158,7 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		}))
 	}
 
-	fn run_instruction<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, opcode: &Opcode) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_instruction<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, opcode: &Opcode) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		match opcode {
 			&Opcode::Unreachable => Interpreter::run_unreachable(context),
 			&Opcode::Nop => Interpreter::run_nop(context),
@@ -352,25 +352,25 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		}
 	}
 
-	fn run_unreachable<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_unreachable<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		Err(Error::Trap("programmatic".into()))
 	}
 
-	fn run_nop<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_nop<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_block<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_block<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.push_frame(labels, BlockFrameType::Block, block_type)?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_loop<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_loop<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.push_frame(labels, BlockFrameType::Loop, block_type)?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_if<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_if<'a>(context: &mut FunctionContext<'a, E>, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let branch = context.value_stack_mut().pop_as()?;
 		let block_frame_type = if branch { BlockFrameType::IfTrue } else {
 			let else_pos = labels[&context.position];
@@ -385,23 +385,23 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		context.push_frame(labels, block_frame_type, block_type).map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_else<'a>(context: &mut FunctionContext<E>, labels: &HashMap<usize, usize>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_else<'a>(context: &mut FunctionContext<E>, labels: &HashMap<usize, usize>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let end_pos = labels[&context.position];
 		context.pop_frame(false)?;
 		context.position = end_pos;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_end<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_end<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.pop_frame(false)?;
 		Ok(InstructionOutcome::End)
 	}
 
-	fn run_br<'a>(_context: &mut FunctionContext<E>, label_idx: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_br<'a>(_context: &mut FunctionContext<E>, label_idx: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		Ok(InstructionOutcome::Branch(label_idx as usize))
 	}
 
-	fn run_br_if<'a>(context: &mut FunctionContext<E>, label_idx: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_br_if<'a>(context: &mut FunctionContext<E>, label_idx: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		if context.value_stack_mut().pop_as()? {
 			Ok(InstructionOutcome::Branch(label_idx as usize))
 		} else {
@@ -409,20 +409,20 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		}
 	}
 
-	fn run_br_table<'a>(context: &mut FunctionContext<E>, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_br_table<'a>(context: &mut FunctionContext<E>, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let index: u32 = context.value_stack_mut().pop_as()?;
 		Ok(InstructionOutcome::Branch(table.get(index as usize).cloned().unwrap_or(default) as usize))
 	}
 
-	fn run_return<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_return<'a>(_context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		Ok(InstructionOutcome::Return)
 	}
 
-	fn run_call<'a>(context: &mut FunctionContext<'a, E>, func_idx: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_call<'a>(context: &mut FunctionContext<'a, E>, func_idx: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		Ok(InstructionOutcome::ExecuteCall(context.module().function_reference(ItemIndex::IndexSpace(func_idx), Some(context.externals))?))
 	}
 
-	fn run_call_indirect<'a>(context: &mut FunctionContext<'a, E>, type_idx: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_call_indirect<'a>(context: &mut FunctionContext<'a, E>, type_idx: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let table_func_idx: u32 = context.value_stack_mut().pop_as()?;
 		let function_reference = context.module().function_reference_indirect(DEFAULT_TABLE_INDEX, type_idx, table_func_idx, Some(context.externals))?;
 		{
@@ -437,54 +437,55 @@ impl<E> Interpreter<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ExecuteCall(function_reference))
 	}
 
-	fn run_drop<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_drop<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context
 			.value_stack_mut()
 			.pop()
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_select<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_select<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context
 			.value_stack_mut()
 			.pop_triple()
-			.and_then(|(left, mid, right)|
-				match (left, mid, right.try_into()) {
+			.and_then(|(left, mid, right)| {
+				let right: Result<_, Error<E>> = right.try_into();
+				match (left, mid, right) {
 					(left, mid, Ok(condition)) => Ok((left, mid, condition)),
 					_ => Err(Error::Stack("expected to get int value from stack".into()))
 				}
-			)
+			})
 			.map(|(left, mid, condition)| if condition { left } else { mid })
 			.map(|val| context.value_stack_mut().push(val))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_get_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_get_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.get_local(index as usize)
 			.map(|value| context.value_stack_mut().push(value))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_set_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_set_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let arg = context.value_stack_mut().pop()?;
 		context.set_local(index as usize, arg)
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_tee_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_tee_local<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let arg = context.value_stack().top()?.clone();
 		context.set_local(index as usize, arg)
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_get_global<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_get_global<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.module()
 			.global(ItemIndex::IndexSpace(index), None, Some(context.externals))
 			.and_then(|g| context.value_stack_mut().push(g.get()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_set_global<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_set_global<'a>(context: &mut FunctionContext<E>, index: u32) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context
 			.value_stack_mut()
 			.pop()
@@ -492,8 +493,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_load<'a, T>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T>, T: LittleEndianConvert {
+	fn run_load<'a, T>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T>, T: LittleEndianConvert<E> {
 		let address = effective_address(offset, context.value_stack_mut().pop_as()?)?;
 		context.module()
 			.memory(ItemIndex::IndexSpace(DEFAULT_MEMORY_INDEX))
@@ -503,8 +504,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_load_extend<'a, T, U>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error>
-		where T: ExtendInto<U>, RuntimeValue: From<U>, T: LittleEndianConvert {
+	fn run_load_extend<'a, T, U>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where T: ExtendInto<U>, RuntimeValue: From<U>, T: LittleEndianConvert<E> {
 		let address = effective_address(offset, context.value_stack_mut().pop_as()?)?;
 		let stack_value: U = context.module()
 			.memory(ItemIndex::IndexSpace(DEFAULT_MEMORY_INDEX))
@@ -517,8 +518,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_store<'a, T>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: LittleEndianConvert {
+	fn run_store<'a, T>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: LittleEndianConvert<E> {
 		let stack_value = context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -530,8 +531,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_store_wrap<'a, T, U>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: WrapInto<U>, U: LittleEndianConvert {
+	fn run_store_wrap<'a, T, U>(context: &mut FunctionContext<E>, _align: u32, offset: u32) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: WrapInto<U>, U: LittleEndianConvert<E> {
 		let stack_value: T = context.value_stack_mut().pop().and_then(|v| v.try_into())?;
 		let stack_value = stack_value.wrap_into().into_little_endian();
 		let address = effective_address(offset, context.value_stack_mut().pop_as::<u32>()?)?;
@@ -541,7 +542,7 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_current_memory<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_current_memory<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context.module()
 			.memory(ItemIndex::IndexSpace(DEFAULT_MEMORY_INDEX))
 			.map(|m| m.size())
@@ -549,7 +550,7 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_grow_memory<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_grow_memory<'a>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		let pages: u32 = context.value_stack_mut().pop_as()?;
 		context.module()
 			.memory(ItemIndex::IndexSpace(DEFAULT_MEMORY_INDEX))
@@ -558,15 +559,15 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_const<'a>(context: &mut FunctionContext<E>, val: RuntimeValue) -> Result<InstructionOutcome<'a, E>, Error> {
+	fn run_const<'a>(context: &mut FunctionContext<E>, val: RuntimeValue) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		context
 			.value_stack_mut()
 			.push(val)
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_eqz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialEq<T> + Default {
+	fn run_eqz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialEq<T> + Default {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -575,8 +576,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_eq<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialEq<T> {
+	fn run_eq<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialEq<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -585,8 +586,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_ne<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialEq<T> {
+	fn run_ne<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialEq<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -595,8 +596,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_lt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialOrd<T> + Display {
+	fn run_lt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialOrd<T> + Display {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -605,8 +606,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_gt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialOrd<T> {
+	fn run_gt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialOrd<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -615,8 +616,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_lte<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialOrd<T> {
+	fn run_lte<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialOrd<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -625,8 +626,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_gte<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: TryInto<T, Error>, T: PartialOrd<T> {
+	fn run_gte<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>>, T: PartialOrd<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -635,8 +636,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_clz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Integer<T> {
+	fn run_clz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Integer<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -645,8 +646,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_ctz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Integer<T> {
+	fn run_ctz<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Integer<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -655,8 +656,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_popcnt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Integer<T> {
+	fn run_popcnt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Integer<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -665,8 +666,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_add<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: ArithmeticOps<T> {
+	fn run_add<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: ArithmeticOps<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -675,8 +676,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_sub<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: ArithmeticOps<T> {
+	fn run_sub<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: ArithmeticOps<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -685,8 +686,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_mul<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: ArithmeticOps<T> {
+	fn run_mul<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: ArithmeticOps<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -695,8 +696,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_div<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: TransmuteInto<U> + Display, U: ArithmeticOps<U> + TransmuteInto<T> {
+	fn run_div<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: TransmuteInto<U> + Display, U: ArithmeticOps<U, E> + TransmuteInto<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -707,8 +708,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_rem<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: TransmuteInto<U>, U: Integer<U> + TransmuteInto<T> {
+	fn run_rem<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: TransmuteInto<U>, U: Integer<U, E> + TransmuteInto<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -719,8 +720,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_and<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<<T as ops::BitAnd>::Output> + TryInto<T, Error>, T: ops::BitAnd<T> {
+	fn run_and<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<<T as ops::BitAnd>::Output> + TryInto<T, Error<E>>, T: ops::BitAnd<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -729,8 +730,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_or<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<<T as ops::BitOr>::Output> + TryInto<T, Error>, T: ops::BitOr<T> {
+	fn run_or<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<<T as ops::BitOr>::Output> + TryInto<T, Error<E>>, T: ops::BitOr<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -739,8 +740,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_xor<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<<T as ops::BitXor>::Output> + TryInto<T, Error>, T: ops::BitXor<T> {
+	fn run_xor<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<<T as ops::BitXor>::Output> + TryInto<T, Error<E>>, T: ops::BitXor<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -749,8 +750,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_shl<'a, T>(context: &mut FunctionContext<E>, mask: T) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<<T as ops::Shl<T>>::Output> + TryInto<T, Error>, T: ops::Shl<T> + ops::BitAnd<T, Output=T> {
+	fn run_shl<'a, T>(context: &mut FunctionContext<E>, mask: T) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<<T as ops::Shl<T>>::Output> + TryInto<T, Error<E>>, T: ops::Shl<T> + ops::BitAnd<T, Output=T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -759,8 +760,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_shr<'a, T, U>(context: &mut FunctionContext<E>, mask: U) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: TransmuteInto<U>, U: ops::Shr<U> + ops::BitAnd<U, Output=U>, <U as ops::Shr<U>>::Output: TransmuteInto<T> {
+	fn run_shr<'a, T, U>(context: &mut FunctionContext<E>, mask: U) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: TransmuteInto<U>, U: ops::Shr<U> + ops::BitAnd<U, Output=U>, <U as ops::Shr<U>>::Output: TransmuteInto<T> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -771,8 +772,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_rotl<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Integer<T> {
+	fn run_rotl<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Integer<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -781,8 +782,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_rotr<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Integer<T> {
+	fn run_rotr<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Integer<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -791,8 +792,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_abs<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_abs<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -801,8 +802,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_neg<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<<T as ops::Neg>::Output> + TryInto<T, Error>, T: ops::Neg {
+	fn run_neg<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<<T as ops::Neg>::Output> + TryInto<T, Error<E>>, T: ops::Neg {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -811,8 +812,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_ceil<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_ceil<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -821,8 +822,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_floor<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_floor<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -831,8 +832,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_trunc<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_trunc<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -841,8 +842,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_nearest<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_nearest<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -851,8 +852,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_sqrt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_sqrt<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -861,8 +862,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_min<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_min<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -871,8 +872,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_max<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_max<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -881,8 +882,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_copysign<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<T> + TryInto<T, Error>, T: Float<T> {
+	fn run_copysign<'a, T>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<T> + TryInto<T, Error<E>>, T: Float<T, E> {
 		context
 			.value_stack_mut()
 			.pop_pair_as::<T>()
@@ -891,8 +892,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_wrap<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<U> + TryInto<T, Error>, T: WrapInto<U> {
+	fn run_wrap<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<U> + TryInto<T, Error<E>>, T: WrapInto<U> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -901,8 +902,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_trunc_to_int<'a, T, U, V>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<V> + TryInto<T, Error>, T: TryTruncateInto<U, Error>, U: TransmuteInto<V>,  {
+	fn run_trunc_to_int<'a, T, U, V>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<V> + TryInto<T, Error<E>>, T: TryTruncateInto<U, Error<E>>, U: TransmuteInto<V>,  {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -912,8 +913,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_extend<'a, T, U, V>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<V> + TryInto<T, Error>, T: ExtendInto<U>, U: TransmuteInto<V> {
+	fn run_extend<'a, T, U, V>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<V> + TryInto<T, Error<E>>, T: ExtendInto<U>, U: TransmuteInto<V> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -923,8 +924,8 @@ impl<E> Interpreter<E> where E: CustomUserError {
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	fn run_reinterpret<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error>
-		where RuntimeValue: From<U>, RuntimeValue: TryInto<T, Error>, T: TransmuteInto<U> {
+	fn run_reinterpret<'a, T, U>(context: &mut FunctionContext<E>) -> Result<InstructionOutcome<'a, E>, Error<E>>
+		where RuntimeValue: From<U>, RuntimeValue: TryInto<T, Error<E>>, T: TransmuteInto<U> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
@@ -935,7 +936,7 @@ impl<E> Interpreter<E> where E: CustomUserError {
 }
 
 impl<'a, E> FunctionContext<'a, E> where E: CustomUserError {
-	pub fn new(function: InternalFunctionReference<'a, E>, externals: &'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>, value_stack_limit: usize, frame_stack_limit: usize, function_type: &FunctionSignature, args: Vec<VariableInstance>) -> Self {
+	pub fn new(function: InternalFunctionReference<'a, E>, externals: &'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>, value_stack_limit: usize, frame_stack_limit: usize, function_type: &FunctionSignature, args: Vec<VariableInstance<E>>) -> Self {
 		FunctionContext {
 			is_initialized: false,
 			function: function,
@@ -948,7 +949,7 @@ impl<'a, E> FunctionContext<'a, E> where E: CustomUserError {
 		}
 	}
 
-	pub fn nested(&mut self, function: InternalFunctionReference<'a, E>) -> Result<Self, Error> {
+	pub fn nested(&mut self, function: InternalFunctionReference<'a, E>) -> Result<Self, Error<E>> {
 		let (function_locals, function_return_type) = {
 			let function_type = function.module.function_type(ItemIndex::Internal(function.internal_index))?;
 			let function_return_type = function_type.return_type().map(|vt| BlockType::Value(vt)).unwrap_or(BlockType::NoResult);
@@ -972,7 +973,7 @@ impl<'a, E> FunctionContext<'a, E> where E: CustomUserError {
 		self.is_initialized
 	}
 
-	pub fn initialize(&mut self, locals: &[Local]) -> Result<(), Error> {
+	pub fn initialize(&mut self, locals: &[Local]) -> Result<(), Error<E>> {
 		debug_assert!(!self.is_initialized);
 		self.is_initialized = true;
 
@@ -992,36 +993,36 @@ impl<'a, E> FunctionContext<'a, E> where E: CustomUserError {
 		&self.externals
 	}
 
-	pub fn set_local(&mut self, index: usize, value: RuntimeValue) -> Result<InstructionOutcome<'a, E>, Error> {
+	pub fn set_local(&mut self, index: usize, value: RuntimeValue) -> Result<InstructionOutcome<'a, E>, Error<E>> {
 		self.locals.get_mut(index)
 			.ok_or(Error::Local(format!("expected to have local with index {}", index)))
 			.and_then(|l| l.set(value))
 			.map(|_| InstructionOutcome::RunNextInstruction)
 	}
 
-	pub fn get_local(&mut self, index: usize) -> Result<RuntimeValue, Error> {
+	pub fn get_local(&mut self, index: usize) -> Result<RuntimeValue, Error<E>> {
 		self.locals.get(index)
 			.ok_or(Error::Local(format!("expected to have local with index {}", index)))
 			.map(|l| l.get())
 	}
 
-	pub fn value_stack(&self) -> &StackWithLimit<RuntimeValue> {
+	pub fn value_stack(&self) -> &StackWithLimit<RuntimeValue, E> {
 		&self.value_stack
 	}
 
-	pub fn value_stack_mut(&mut self) -> &mut StackWithLimit<RuntimeValue> {
+	pub fn value_stack_mut(&mut self) -> &mut StackWithLimit<RuntimeValue, E> {
 		&mut self.value_stack
 	}
 
-	pub fn frame_stack(&self) -> &StackWithLimit<BlockFrame> {
+	pub fn frame_stack(&self) -> &StackWithLimit<BlockFrame, E> {
 		&self.frame_stack
 	}
 
-	pub fn frame_stack_mut(&mut self) -> &mut StackWithLimit<BlockFrame> {
+	pub fn frame_stack_mut(&mut self) -> &mut StackWithLimit<BlockFrame, E> {
 		&mut self.frame_stack
 	}
 
-	pub fn push_frame(&mut self, labels: &HashMap<usize, usize>, frame_type: BlockFrameType, block_type: BlockType) -> Result<(), Error> {
+	pub fn push_frame(&mut self, labels: &HashMap<usize, usize>, frame_type: BlockFrameType, block_type: BlockType) -> Result<(), Error<E>> {
 		let begin_position = self.position;
 		let branch_position = match frame_type {
 			BlockFrameType::Function => usize::MAX,
@@ -1049,12 +1050,12 @@ impl<'a, E> FunctionContext<'a, E> where E: CustomUserError {
 		})
 	}
 
-	pub fn discard_frame(&mut self) -> Result<(), Error> {
+	pub fn discard_frame(&mut self) -> Result<(), Error<E>> {
 		self.frame_stack.pop()
 			.map(|_| ())
 	}
 
-	pub fn pop_frame(&mut self, is_branch: bool) -> Result<(), Error> {
+	pub fn pop_frame(&mut self, is_branch: bool) -> Result<(), Error<E>> {
 		let frame = self.frame_stack.pop()?;
 		if frame.value_stack_len > self.value_stack.len() {
 			return Err(Error::Stack("invalid stack len".into()));
@@ -1080,14 +1081,14 @@ impl<'a, E> fmt::Debug for FunctionContext<'a, E> where E: CustomUserError {
 	}
 }
 
-fn effective_address(address: u32, offset: u32) -> Result<u32, Error> {
+fn effective_address<E: CustomUserError>(address: u32, offset: u32) -> Result<u32, Error<E>> {
 	match offset.checked_add(address) {
 		None => Err(Error::Memory(format!("invalid memory access: {} + {}", offset, address))),
 		Some(address) => Ok(address),
 	}
 }
 
-pub fn prepare_function_args(function_type: &FunctionSignature, caller_stack: &mut StackWithLimit<RuntimeValue>) -> Result<Vec<VariableInstance>, Error> {
+pub fn prepare_function_args<E: CustomUserError>(function_type: &FunctionSignature, caller_stack: &mut StackWithLimit<RuntimeValue, E>) -> Result<Vec<VariableInstance<E>>, Error<E>> {
 	let mut args = function_type.params().iter().rev().map(|param_type| {
 		let param_value = caller_stack.pop()?;
 		let actual_type = param_value.variable_type();

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::value::{RuntimeValue, TryInto};
 
 /// Stack with limit.
 #[derive(Debug)]
-pub struct StackWithLimit<T, E> where T: Clone, E: CustomUserError {
+pub struct StackWithLimit<T, E> where T: Clone, E: UserError {
 	/// Stack values.
 	values: VecDeque<T>,
 	/// Stack limit (maximal stack len).
@@ -13,7 +13,7 @@ pub struct StackWithLimit<T, E> where T: Clone, E: CustomUserError {
 	_dummy: ::std::marker::PhantomData<E>,
 }
 
-impl<T, E> StackWithLimit<T, E> where T: Clone, E: CustomUserError {
+impl<T, E> StackWithLimit<T, E> where T: Clone, E: UserError {
 	pub fn with_data(data: Vec<T>, limit: usize) -> Self {
 		StackWithLimit {
 			values: data.into_iter().collect(),
@@ -100,7 +100,7 @@ impl<T, E> StackWithLimit<T, E> where T: Clone, E: CustomUserError {
 	}
 }
 
-impl<E> StackWithLimit<RuntimeValue, E> where E: CustomUserError {
+impl<E> StackWithLimit<RuntimeValue, E> where E: UserError {
 	pub fn pop_as<T>(&mut self) -> Result<T, Error<E>>
 		where RuntimeValue: TryInto<T, Error<E>> {
 		self.pop().and_then(TryInto::try_into)

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -1,21 +1,24 @@
 use std::collections::VecDeque;
-use interpreter::Error;
+use interpreter::{Error, CustomUserError};
 use interpreter::value::{RuntimeValue, TryInto};
 
 /// Stack with limit.
 #[derive(Debug)]
-pub struct StackWithLimit<T> where T: Clone {
+pub struct StackWithLimit<T, E> where T: Clone, E: CustomUserError {
 	/// Stack values.
 	values: VecDeque<T>,
 	/// Stack limit (maximal stack len).
 	limit: usize,
+	/// Dummy to avoid compilation error.
+	_dummy: ::std::marker::PhantomData<E>,
 }
 
-impl<T> StackWithLimit<T> where T: Clone {
+impl<T, E> StackWithLimit<T, E> where T: Clone, E: CustomUserError {
 	pub fn with_data(data: Vec<T>, limit: usize) -> Self {
 		StackWithLimit {
 			values: data.into_iter().collect(),
 			limit: limit,
+			_dummy: Default::default(),
 		}
 	}
 	
@@ -23,6 +26,7 @@ impl<T> StackWithLimit<T> where T: Clone {
 		StackWithLimit {
 			values: VecDeque::new(),
 			limit: limit,
+			_dummy: Default::default(),
 		}
 	}
 
@@ -42,19 +46,19 @@ impl<T> StackWithLimit<T> where T: Clone {
 		&self.values
 	}
 
-	pub fn top(&self) -> Result<&T, Error> {
+	pub fn top(&self) -> Result<&T, Error<E>> {
 		self.values
 			.back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
 	}
 
-	pub fn top_mut(&mut self) -> Result<&mut T, Error> {
+	pub fn top_mut(&mut self) -> Result<&mut T, Error<E>> {
 		self.values
 			.back_mut()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
 	}
 
-	pub fn get(&self, index: usize) -> Result<&T, Error> {
+	pub fn get(&self, index: usize) -> Result<&T, Error<E>> {
 		if index >= self.values.len() {
 			return Err(Error::Stack(format!("trying to get value at position {} on stack of size {}", index, self.values.len())));
 		}
@@ -62,7 +66,7 @@ impl<T> StackWithLimit<T> where T: Clone {
 		Ok(self.values.get(self.values.len() - 1 - index).expect("checked couple of lines above"))
 	}
 
-	pub fn push(&mut self, value: T) -> Result<(), Error> {
+	pub fn push(&mut self, value: T) -> Result<(), Error<E>> {
 		if self.values.len() >= self.limit {
 			return Err(Error::Stack(format!("exceeded stack limit {}", self.limit)));
 		}
@@ -71,7 +75,7 @@ impl<T> StackWithLimit<T> where T: Clone {
 		Ok(())
 	}
 
-	pub fn push_penultimate(&mut self, value: T) -> Result<(), Error> {
+	pub fn push_penultimate(&mut self, value: T) -> Result<(), Error<E>> {
 		if self.values.is_empty() {
 			return Err(Error::Stack("trying to insert penultimate element into empty stack".into()));
 		}
@@ -84,7 +88,7 @@ impl<T> StackWithLimit<T> where T: Clone {
 		Ok(())
 	}
 
-	pub fn pop(&mut self) -> Result<T, Error> {
+	pub fn pop(&mut self) -> Result<T, Error<E>> {
 		self.values
 			.pop_back()
 			.ok_or(Error::Stack("non-empty stack expected".into()))
@@ -96,26 +100,26 @@ impl<T> StackWithLimit<T> where T: Clone {
 	}
 }
 
-impl StackWithLimit<RuntimeValue> {
-	pub fn pop_as<T>(&mut self) -> Result<T, Error>
-		where RuntimeValue: TryInto<T, Error> {
+impl<E> StackWithLimit<RuntimeValue, E> where E: CustomUserError {
+	pub fn pop_as<T>(&mut self) -> Result<T, Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>> {
 		self.pop().and_then(TryInto::try_into)
 	}
 
-	pub fn pop_pair(&mut self) -> Result<(RuntimeValue, RuntimeValue), Error> {
+	pub fn pop_pair(&mut self) -> Result<(RuntimeValue, RuntimeValue), Error<E>> {
 		let right = self.pop()?;
 		let left = self.pop()?;
 		Ok((left, right))
 	}
 
-	pub fn pop_pair_as<T>(&mut self) -> Result<(T, T), Error>
-		where RuntimeValue: TryInto<T, Error> {
+	pub fn pop_pair_as<T>(&mut self) -> Result<(T, T), Error<E>>
+		where RuntimeValue: TryInto<T, Error<E>> {
 		let right = self.pop_as()?;
 		let left = self.pop_as()?;
 		Ok((left, right))
 	}
 
-	pub fn pop_triple(&mut self) -> Result<(RuntimeValue, RuntimeValue, RuntimeValue), Error> {
+	pub fn pop_triple(&mut self) -> Result<(RuntimeValue, RuntimeValue, RuntimeValue), Error<E>> {
 		let right = self.pop()?;
 		let mid = self.pop()?;
 		let left = self.pop()?;

--- a/src/interpreter/table.rs
+++ b/src/interpreter/table.rs
@@ -2,13 +2,13 @@ use std::u32;
 use std::sync::Arc;
 use parking_lot::RwLock;
 use elements::TableType;
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::module::check_limits;
 use interpreter::variable::{VariableInstance, VariableType};
 use interpreter::value::RuntimeValue;
 
 /// Table instance.
-pub struct TableInstance<E: CustomUserError> {
+pub struct TableInstance<E: UserError> {
 	/// Table variables type.
 	variable_type: VariableType,
 	/// Table memory buffer.
@@ -16,11 +16,11 @@ pub struct TableInstance<E: CustomUserError> {
 }
 
 /// Table element. Cloneable wrapper around VariableInstance.
-struct TableElement<E: CustomUserError> {
+struct TableElement<E: UserError> {
 	pub var: VariableInstance<E>,
 }
 
-impl<E> TableInstance<E> where E: CustomUserError {
+impl<E> TableInstance<E> where E: UserError {
 	/// New instance of the table
 	pub fn new(table_type: &TableType) -> Result<Arc<Self>, Error<E>> {
 		check_limits(table_type.limits())?;
@@ -70,7 +70,7 @@ impl<E> TableInstance<E> where E: CustomUserError {
 	}
 }
 
-impl<E> TableElement<E> where E: CustomUserError {
+impl<E> TableElement<E> where E: UserError {
 	pub fn new(var: VariableInstance<E>) -> Self {
 		TableElement {
 			var: var,
@@ -78,7 +78,7 @@ impl<E> TableElement<E> where E: CustomUserError {
 	}
 }
 
-impl<E> Clone for TableElement<E> where E: CustomUserError {
+impl<E> Clone for TableElement<E> where E: UserError {
 	fn clone(&self) -> Self {
 		TableElement::new(VariableInstance::new(self.var.is_mutable(), self.var.variable_type(), self.var.get())
 			.expect("it only fails when variable_type() != passed variable value; both are read from already constructed var; qed"))

--- a/src/interpreter/table.rs
+++ b/src/interpreter/table.rs
@@ -2,27 +2,27 @@ use std::u32;
 use std::sync::Arc;
 use parking_lot::RwLock;
 use elements::TableType;
-use interpreter::Error;
+use interpreter::{Error, CustomUserError};
 use interpreter::module::check_limits;
 use interpreter::variable::{VariableInstance, VariableType};
 use interpreter::value::RuntimeValue;
 
 /// Table instance.
-pub struct TableInstance {
+pub struct TableInstance<E: CustomUserError> {
 	/// Table variables type.
 	variable_type: VariableType,
 	/// Table memory buffer.
-	buffer: RwLock<Vec<TableElement>>,
+	buffer: RwLock<Vec<TableElement<E>>>,
 }
 
 /// Table element. Cloneable wrapper around VariableInstance.
-struct TableElement {
-	pub var: VariableInstance,
+struct TableElement<E: CustomUserError> {
+	pub var: VariableInstance<E>,
 }
 
-impl TableInstance {
+impl<E> TableInstance<E> where E: CustomUserError {
 	/// New instance of the table
-	pub fn new(table_type: &TableType) -> Result<Arc<Self>, Error> {
+	pub fn new(table_type: &TableType) -> Result<Arc<Self>, Error<E>> {
 		check_limits(table_type.limits())?;
 
 		let variable_type = table_type.elem_type().into();
@@ -40,7 +40,7 @@ impl TableInstance {
 	}
 
 	/// Get the specific value in the table
-	pub fn get(&self, offset: u32) -> Result<RuntimeValue, Error> {
+	pub fn get(&self, offset: u32) -> Result<RuntimeValue, Error<E>> {
 		let buffer = self.buffer.read();
 		let buffer_len = buffer.len();
 		buffer.get(offset as usize)
@@ -49,7 +49,7 @@ impl TableInstance {
 	}
 
 	/// Set the table value from raw slice
-	pub fn set_raw(&self, mut offset: u32, module_name: String, value: &[u32]) -> Result<(), Error> {
+	pub fn set_raw(&self, mut offset: u32, module_name: String, value: &[u32]) -> Result<(), Error<E>> {
 		for val in value {
 			match self.variable_type {
 				VariableType::AnyFunc => self.set(offset, RuntimeValue::AnyFunc(module_name.clone(), *val))?,
@@ -61,7 +61,7 @@ impl TableInstance {
 	}
 
 	/// Set the table from runtime variable value
-	pub fn set(&self, offset: u32, value: RuntimeValue) -> Result<(), Error> {
+	pub fn set(&self, offset: u32, value: RuntimeValue) -> Result<(), Error<E>> {
 		let mut buffer = self.buffer.write();
 		let buffer_len = buffer.len();
 		buffer.get_mut(offset as usize)
@@ -70,15 +70,15 @@ impl TableInstance {
 	}
 }
 
-impl TableElement {
-	pub fn new(var: VariableInstance) -> Self {
+impl<E> TableElement<E> where E: CustomUserError {
+	pub fn new(var: VariableInstance<E>) -> Self {
 		TableElement {
 			var: var,
 		}
 	}
 }
 
-impl Clone for TableElement {
+impl<E> Clone for TableElement<E> where E: CustomUserError {
 	fn clone(&self) -> Self {
 		TableElement::new(VariableInstance::new(self.var.is_mutable(), self.var.variable_type(), self.var.get())
 			.expect("it only fails when variable_type() != passed variable value; both are read from already constructed var; qed"))

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use builder::module;
 use elements::{ValueType, Opcodes, Opcode, BlockType, Local};
-use interpreter::{Error, DummyUserError, DefaultProgramInstance, DefaultModuleInstanceInterface, ModuleInstanceInterface, ItemIndex};
+use interpreter::{Error, DummyError, DefaultProgramInstance, DefaultModuleInstanceInterface, ModuleInstanceInterface, ItemIndex};
 use interpreter::value::{RuntimeValue, TryInto};
 
 fn make_function_i32(body: Opcodes) -> (DefaultProgramInstance, Arc<DefaultModuleInstanceInterface>) {
@@ -22,7 +22,7 @@ fn make_function_i32(body: Opcodes) -> (DefaultProgramInstance, Arc<DefaultModul
 	(program, module)
 }
 
-fn run_function_i32(module: &Arc<DefaultModuleInstanceInterface>, arg: i32) -> Result<i32, Error<DummyUserError>> {
+fn run_function_i32(module: &Arc<DefaultModuleInstanceInterface>, arg: i32) -> Result<i32, DummyError> {
 	module
 		.execute_index(0, vec![RuntimeValue::I32(arg)].into())
 		.and_then(|r| r.unwrap().try_into())

--- a/src/interpreter/tests/wabt.rs
+++ b/src/interpreter/tests/wabt.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use builder::module;
 use elements::{ValueType, Opcodes, Opcode, BlockType, Local};
-use interpreter::{Error, DummyCustomUserError, DefaultProgramInstance, DefaultModuleInstanceInterface, ModuleInstanceInterface, ItemIndex};
+use interpreter::{Error, DummyUserError, DefaultProgramInstance, DefaultModuleInstanceInterface, ModuleInstanceInterface, ItemIndex};
 use interpreter::value::{RuntimeValue, TryInto};
 
 fn make_function_i32(body: Opcodes) -> (DefaultProgramInstance, Arc<DefaultModuleInstanceInterface>) {
@@ -22,7 +22,7 @@ fn make_function_i32(body: Opcodes) -> (DefaultProgramInstance, Arc<DefaultModul
 	(program, module)
 }
 
-fn run_function_i32(module: &Arc<DefaultModuleInstanceInterface>, arg: i32) -> Result<i32, Error<DummyCustomUserError>> {
+fn run_function_i32(module: &Arc<DefaultModuleInstanceInterface>, arg: i32) -> Result<i32, Error<DummyUserError>> {
 	module
 		.execute_index(0, vec![RuntimeValue::I32(arg)].into())
 		.and_then(|r| r.unwrap().try_into())

--- a/src/interpreter/tests/wasm.rs
+++ b/src/interpreter/tests/wasm.rs
@@ -1,6 +1,6 @@
 use elements::deserialize_file;
 use elements::Module;
-use interpreter::{EnvParams, ExecutionParams, ProgramInstance};
+use interpreter::{EnvParams, ExecutionParams, DefaultProgramInstance};
 use interpreter::module::ModuleInstanceInterface;
 use interpreter::value::RuntimeValue;
 
@@ -12,7 +12,7 @@ const WASM_FILE: &str = &"res/cases/v1/inc_i32.wasm";
 
 #[test]
 fn interpreter_inc_i32() {
-    let program = ProgramInstance::with_env_params(EnvParams {
+    let program = DefaultProgramInstance::with_env_params(EnvParams {
         total_stack: 128 * 1024,
         total_memory: 2 * 1024 * 1024,
         allow_memory_growth: false,

--- a/src/interpreter/tests/wasm.rs
+++ b/src/interpreter/tests/wasm.rs
@@ -1,9 +1,7 @@
 use elements::deserialize_file;
 use elements::Module;
-use interpreter::EnvParams;
-use interpreter::ExecutionParams;
+use interpreter::{EnvParams, ExecutionParams, ProgramInstance};
 use interpreter::module::ModuleInstanceInterface;
-use interpreter::program::ProgramInstance;
 use interpreter::value::RuntimeValue;
 
 // Name of function contained in WASM file (note the leading underline)

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -2,7 +2,7 @@ use std::u32;
 use std::sync::Arc;
 use std::collections::HashMap;
 use elements::{Opcode, BlockType, ValueType};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::runner::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 use interpreter::module::{ModuleInstance, ModuleInstanceInterface, ItemIndex, FunctionSignature};
 use interpreter::stack::StackWithLimit;
@@ -12,7 +12,7 @@ use interpreter::variable::VariableType;
 const NATURAL_ALIGNMENT: u32 = 0xFFFFFFFF;
 
 /// Function validation context.
-pub struct FunctionValidationContext<'a, E: 'a + CustomUserError> {
+pub struct FunctionValidationContext<'a, E: 'a + UserError> {
 	/// Wasm module instance (in process of instantiation).
 	module_instance: &'a ModuleInstance<E>,
 	/// Native externals.
@@ -75,7 +75,7 @@ pub enum BlockFrameType {
 }
 
 /// Function validator.
-pub struct Validator<E: CustomUserError> {
+pub struct Validator<E: UserError> {
 	_dummy: ::std::marker::PhantomData<E>,
 }
 
@@ -88,7 +88,7 @@ pub enum InstructionOutcome {
 	Unreachable,
 }
 
-impl<E> Validator<E> where E: CustomUserError {
+impl<E> Validator<E> where E: UserError {
 	pub fn validate_function(context: &mut FunctionValidationContext<E>, block_type: BlockType, body: &[Opcode]) -> Result<(), Error<E>> {
 		context.push_label(BlockFrameType::Function, block_type)?;
 		Validator::validate_function_block(context, body)?;
@@ -571,7 +571,7 @@ impl<E> Validator<E> where E: CustomUserError {
 	}
 }
 
-impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
+impl<'a, E> FunctionValidationContext<'a, E> where E: UserError {
 	pub fn new(
 		module_instance: &'a ModuleInstance<E>, 
 		externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>,

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -22,9 +22,9 @@ pub struct FunctionValidationContext<'a, E: 'a + CustomUserError> {
 	/// Local variables.
 	locals: &'a [ValueType],
 	/// Value stack.
-	value_stack: StackWithLimit<StackValueType>,
+	value_stack: StackWithLimit<StackValueType, E>,
 	/// Frame stack.
-	frame_stack: StackWithLimit<BlockFrame>,
+	frame_stack: StackWithLimit<BlockFrame, E>,
 	/// Function return type. None if validating expression.
 	return_type: Option<BlockType>,
 	/// Labels positions.
@@ -89,7 +89,7 @@ pub enum InstructionOutcome {
 }
 
 impl<E> Validator<E> where E: CustomUserError {
-	pub fn validate_function(context: &mut FunctionValidationContext<E>, block_type: BlockType, body: &[Opcode]) -> Result<(), Error> {
+	pub fn validate_function(context: &mut FunctionValidationContext<E>, block_type: BlockType, body: &[Opcode]) -> Result<(), Error<E>> {
 		context.push_label(BlockFrameType::Function, block_type)?;
 		Validator::validate_function_block(context, body)?;
 		while !context.frame_stack.is_empty() {
@@ -99,7 +99,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(())
 	}
 
-	fn validate_function_block(context: &mut FunctionValidationContext<E>, body: &[Opcode]) -> Result<(), Error> {
+	fn validate_function_block(context: &mut FunctionValidationContext<E>, body: &[Opcode]) -> Result<(), Error<E>> {
 		let body_len = body.len();
 		if body_len == 0 {
 			return Err(Error::Validation("Non-empty function body expected".into()));
@@ -119,7 +119,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		}
 	}
 
-	fn validate_instruction(context: &mut FunctionValidationContext<E>, opcode: &Opcode) -> Result<InstructionOutcome, Error> {
+	fn validate_instruction(context: &mut FunctionValidationContext<E>, opcode: &Opcode) -> Result<InstructionOutcome, Error<E>> {
 		debug!(target: "validator", "validating {:?}", opcode);
 		match opcode {
 			&Opcode::Unreachable => Ok(InstructionOutcome::Unreachable),
@@ -314,49 +314,49 @@ impl<E> Validator<E> where E: CustomUserError {
 		}
 	}
 
-	fn validate_const(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_const(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_unop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_unop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_binop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_binop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_testop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_testop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_relop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_relop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_cvtop(context: &mut FunctionValidationContext<E>, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_cvtop(context: &mut FunctionValidationContext<E>, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(value_type1)?;
 		context.push_value(value_type2)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_drop(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_drop(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_any_value().map(|_| ())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_select(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_select(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(ValueType::I32.into())?;
 		let select_type = context.pop_any_value()?;
 		context.pop_value(select_type)?;
@@ -364,13 +364,13 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error<E>> {
 		let local_type = context.require_local(index)?;
 		context.push_value(local_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error<E>> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.pop_any_value()?;
 		if local_type != value_type {
@@ -379,7 +379,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_tee_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_tee_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error<E>> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.tee_any_value()?;
 		if local_type != value_type {
@@ -388,13 +388,13 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error<E>> {
 		let global_type = context.require_global(index, None)?;
 		context.push_value(global_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error<E>> {
 		let global_type = context.require_global(index, Some(true))?;
 		let value_type = context.pop_any_value()?;
 		if global_type != value_type {
@@ -403,7 +403,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_load(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_load(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -416,7 +416,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_store(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_store(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error<E>> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -429,20 +429,20 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_block(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_block(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error<E>> {
 		context.push_label(BlockFrameType::Block, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_loop(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_loop(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error<E>> {
 		context.push_label(BlockFrameType::Loop, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_if(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_if(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(ValueType::I32.into())?;
 		context.push_label(BlockFrameType::IfTrue, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_else(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_else(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		let block_type = {
 			let top_frame = context.top_label()?;
 			if top_frame.frame_type != BlockFrameType::IfTrue {
@@ -458,7 +458,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		context.push_label(BlockFrameType::IfFalse, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_end(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_end(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		{
 			let top_frame = context.top_label()?;
 			if top_frame.frame_type == BlockFrameType::IfTrue {
@@ -471,7 +471,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		context.pop_label().map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error<E>> {
 		let (frame_type, frame_block_type) = {
 			let frame = context.require_label(idx)?;
 			(frame.frame_type, frame.block_type)
@@ -485,7 +485,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_br_if(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_if(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error<E>> {
 		context.pop_value(ValueType::I32.into())?;
 		if let BlockType::Value(value_type) = context.require_label(idx)?.block_type {
 			context.tee_value(value_type.into())?;
@@ -493,7 +493,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br_table(context: &mut FunctionValidationContext<E>, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_table(context: &mut FunctionValidationContext<E>, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error<E>> {
 		let mut required_block_type = None;
 		
 		{
@@ -525,14 +525,14 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_return(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_return(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		if let BlockType::Value(value_type) = context.return_type()? {
 			context.tee_value(value_type.into())?;
 		}
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_call(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error<E>> {
 		let (argument_types, return_type) = context.require_function(idx)?;
 		for argument_type in argument_types.iter().rev() {
 			context.pop_value((*argument_type).into())?;
@@ -543,7 +543,7 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_call_indirect(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call_indirect(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error<E>> {
 		context.require_table(DEFAULT_TABLE_INDEX, VariableType::AnyFunc)?;
 
 		context.pop_value(ValueType::I32.into())?;
@@ -557,13 +557,13 @@ impl<E> Validator<E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_current_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_current_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_grow_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
+	fn validate_grow_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error<E>> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.pop_value(ValueType::I32.into())?;
 		context.push_value(ValueType::I32.into())?;
@@ -592,11 +592,11 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		}
 	}
 
-	pub fn push_value(&mut self, value_type: StackValueType) -> Result<(), Error> {
+	pub fn push_value(&mut self, value_type: StackValueType) -> Result<(), Error<E>> {
 		self.value_stack.push(value_type.into())
 	}
 
-	pub fn pop_value(&mut self, value_type: StackValueType) -> Result<(), Error> {
+	pub fn pop_value(&mut self, value_type: StackValueType) -> Result<(), Error<E>> {
 		self.check_stack_access()?;
 		match self.value_stack.pop()? {
 			StackValueType::Specific(stack_value_type) if stack_value_type == value_type => Ok(()),
@@ -609,7 +609,7 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		}
 	}
 
-	pub fn tee_value(&mut self, value_type: StackValueType) -> Result<(), Error> {
+	pub fn tee_value(&mut self, value_type: StackValueType) -> Result<(), Error<E>> {
 		self.check_stack_access()?;
 		match *self.value_stack.top()? {
 			StackValueType::Specific(stack_value_type) if stack_value_type == value_type => Ok(()),
@@ -618,7 +618,7 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		}
 	}
 
-	pub fn pop_any_value(&mut self) -> Result<StackValueType, Error> {
+	pub fn pop_any_value(&mut self) -> Result<StackValueType, Error<E>> {
 		self.check_stack_access()?;
 		match self.value_stack.pop()? {
 			StackValueType::Specific(stack_value_type) => Ok(StackValueType::Specific(stack_value_type)),
@@ -630,20 +630,20 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		}
 	}
 
-	pub fn tee_any_value(&mut self) -> Result<StackValueType, Error> {
+	pub fn tee_any_value(&mut self) -> Result<StackValueType, Error<E>> {
 		self.check_stack_access()?;
 		self.value_stack.top().map(Clone::clone)
 	}
 
-	pub fn unreachable(&mut self) -> Result<(), Error> {
+	pub fn unreachable(&mut self) -> Result<(), Error<E>> {
 		self.value_stack.push(StackValueType::AnyUnlimited)
 	}
 
-	pub fn top_label(&self) -> Result<&BlockFrame, Error> {
+	pub fn top_label(&self) -> Result<&BlockFrame, Error<E>> {
 		self.frame_stack.top()
 	}
 
-	pub fn push_label(&mut self, frame_type: BlockFrameType, block_type: BlockType) -> Result<(), Error> {
+	pub fn push_label(&mut self, frame_type: BlockFrameType, block_type: BlockType) -> Result<(), Error<E>> {
 		self.frame_stack.push(BlockFrame {
 			frame_type: frame_type,
 			block_type: block_type,
@@ -654,7 +654,7 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		})
 	}
 
-	pub fn pop_label(&mut self) -> Result<InstructionOutcome, Error> {
+	pub fn pop_label(&mut self) -> Result<InstructionOutcome, Error<E>> {
 		let frame = self.frame_stack.pop()?;
 		let actual_value_type = if self.value_stack.len() > frame.value_stack_len {
 			Some(self.value_stack.pop()?)
@@ -678,22 +678,22 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	pub fn require_label(&self, idx: u32) -> Result<&BlockFrame, Error> {
+	pub fn require_label(&self, idx: u32) -> Result<&BlockFrame, Error<E>> {
 		self.frame_stack.get(idx as usize)	
 	}
 
-	pub fn return_type(&self) -> Result<BlockType, Error> {
+	pub fn return_type(&self) -> Result<BlockType, Error<E>> {
 		self.return_type.ok_or(Error::Validation("Trying to return from expression".into()))
 	}
 
-	pub fn require_local(&self, idx: u32) -> Result<StackValueType, Error> {
+	pub fn require_local(&self, idx: u32) -> Result<StackValueType, Error<E>> {
 		self.locals.get(idx as usize)
 			.cloned()
 			.map(Into::into)
 			.ok_or(Error::Validation(format!("Trying to access local with index {} when there are only {} locals", idx, self.locals.len())))
 	}
 
-	pub fn require_global(&self, idx: u32, mutability: Option<bool>) -> Result<StackValueType, Error> {
+	pub fn require_global(&self, idx: u32, mutability: Option<bool>) -> Result<StackValueType, Error<E>> {
 		self.module_instance
 			.global(ItemIndex::IndexSpace(idx), None, self.externals.clone())
 			.and_then(|g| match mutability {
@@ -709,13 +709,13 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 			})
 	}
 
-	pub fn require_memory(&self, idx: u32) -> Result<(), Error> {
+	pub fn require_memory(&self, idx: u32) -> Result<(), Error<E>> {
 		self.module_instance
 			.memory(ItemIndex::IndexSpace(idx))
 			.map(|_| ())
 	}
 
-	pub fn require_table(&self, idx: u32, variable_type: VariableType) -> Result<(), Error> {
+	pub fn require_table(&self, idx: u32, variable_type: VariableType) -> Result<(), Error<E>> {
 		self.module_instance
 			.table(ItemIndex::IndexSpace(idx))
 			.and_then(|t| if t.variable_type() == variable_type {
@@ -725,12 +725,12 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 			})
 	}
 
-	pub fn require_function(&self, idx: u32) -> Result<(Vec<ValueType>, BlockType), Error> {
+	pub fn require_function(&self, idx: u32) -> Result<(Vec<ValueType>, BlockType), Error<E>> {
 		self.module_instance.function_type(ItemIndex::IndexSpace(idx))
 			.map(|ft| (ft.params().to_vec(), ft.return_type().map(BlockType::Value).unwrap_or(BlockType::NoResult)))
 	}
 
-	pub fn require_function_type(&self, idx: u32) -> Result<(Vec<ValueType>, BlockType), Error> {
+	pub fn require_function_type(&self, idx: u32) -> Result<(Vec<ValueType>, BlockType), Error<E>> {
 		self.module_instance.function_type_by_index(idx)
 			.map(|ft| (ft.params().to_vec(), ft.return_type().map(BlockType::Value).unwrap_or(BlockType::NoResult)))
 	}
@@ -739,7 +739,7 @@ impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 		self.labels
 	}
 
-	fn check_stack_access(&self) -> Result<(), Error> {
+	fn check_stack_access(&self) -> Result<(), Error<E>> {
 		let value_stack_min = self.frame_stack.top().expect("at least 1 topmost block").value_stack_len;
 		if self.value_stack.len() > value_stack_min {
 			Ok(())

--- a/src/interpreter/validator.rs
+++ b/src/interpreter/validator.rs
@@ -2,7 +2,7 @@ use std::u32;
 use std::sync::Arc;
 use std::collections::HashMap;
 use elements::{Opcode, BlockType, ValueType};
-use interpreter::Error;
+use interpreter::{Error, CustomUserError};
 use interpreter::runner::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 use interpreter::module::{ModuleInstance, ModuleInstanceInterface, ItemIndex, FunctionSignature};
 use interpreter::stack::StackWithLimit;
@@ -12,11 +12,11 @@ use interpreter::variable::VariableType;
 const NATURAL_ALIGNMENT: u32 = 0xFFFFFFFF;
 
 /// Function validation context.
-pub struct FunctionValidationContext<'a> {
+pub struct FunctionValidationContext<'a, E: 'a + CustomUserError> {
 	/// Wasm module instance (in process of instantiation).
-	module_instance: &'a ModuleInstance,
+	module_instance: &'a ModuleInstance<E>,
 	/// Native externals.
-	externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>,
+	externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>,
 	/// Current instruction position.
 	position: usize,
 	/// Local variables.
@@ -75,7 +75,9 @@ pub enum BlockFrameType {
 }
 
 /// Function validator.
-pub struct Validator;
+pub struct Validator<E: CustomUserError> {
+	_dummy: ::std::marker::PhantomData<E>,
+}
 
 /// Instruction outcome.
 #[derive(Debug, Clone)]
@@ -86,8 +88,8 @@ pub enum InstructionOutcome {
 	Unreachable,
 }
 
-impl Validator {
-	pub fn validate_function(context: &mut FunctionValidationContext, block_type: BlockType, body: &[Opcode]) -> Result<(), Error> {
+impl<E> Validator<E> where E: CustomUserError {
+	pub fn validate_function(context: &mut FunctionValidationContext<E>, block_type: BlockType, body: &[Opcode]) -> Result<(), Error> {
 		context.push_label(BlockFrameType::Function, block_type)?;
 		Validator::validate_function_block(context, body)?;
 		while !context.frame_stack.is_empty() {
@@ -97,7 +99,7 @@ impl Validator {
 		Ok(())
 	}
 
-	fn validate_function_block(context: &mut FunctionValidationContext, body: &[Opcode]) -> Result<(), Error> {
+	fn validate_function_block(context: &mut FunctionValidationContext<E>, body: &[Opcode]) -> Result<(), Error> {
 		let body_len = body.len();
 		if body_len == 0 {
 			return Err(Error::Validation("Non-empty function body expected".into()));
@@ -117,7 +119,7 @@ impl Validator {
 		}
 	}
 
-	fn validate_instruction(context: &mut FunctionValidationContext, opcode: &Opcode) -> Result<InstructionOutcome, Error> {
+	fn validate_instruction(context: &mut FunctionValidationContext<E>, opcode: &Opcode) -> Result<InstructionOutcome, Error> {
 		debug!(target: "validator", "validating {:?}", opcode);
 		match opcode {
 			&Opcode::Unreachable => Ok(InstructionOutcome::Unreachable),
@@ -312,49 +314,49 @@ impl Validator {
 		}
 	}
 
-	fn validate_const(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_const(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_unop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_unop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_binop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_binop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(value_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_testop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_testop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_relop(context: &mut FunctionValidationContext, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_relop(context: &mut FunctionValidationContext<E>, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type)?;
 		context.pop_value(value_type)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_cvtop(context: &mut FunctionValidationContext, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_cvtop(context: &mut FunctionValidationContext<E>, value_type1: StackValueType, value_type2: StackValueType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(value_type1)?;
 		context.push_value(value_type2)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_drop(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_drop(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		context.pop_any_value().map(|_| ())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_select(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_select(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		let select_type = context.pop_any_value()?;
 		context.pop_value(select_type)?;
@@ -362,13 +364,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		context.push_value(local_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.pop_any_value()?;
 		if local_type != value_type {
@@ -377,7 +379,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_tee_local(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_tee_local(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
 		let local_type = context.require_local(index)?;
 		let value_type = context.tee_any_value()?;
 		if local_type != value_type {
@@ -386,13 +388,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_get_global(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_get_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
 		let global_type = context.require_global(index, None)?;
 		context.push_value(global_type)?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_set_global(context: &mut FunctionValidationContext, index: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_set_global(context: &mut FunctionValidationContext<E>, index: u32) -> Result<InstructionOutcome, Error> {
 		let global_type = context.require_global(index, Some(true))?;
 		let value_type = context.pop_any_value()?;
 		if global_type != value_type {
@@ -401,7 +403,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_load(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_load(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -414,7 +416,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_store(context: &mut FunctionValidationContext, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
+	fn validate_store(context: &mut FunctionValidationContext<E>, align: u32, max_align: u32, value_type: StackValueType) -> Result<InstructionOutcome, Error> {
 		if align != NATURAL_ALIGNMENT {
 			if 1u32.checked_shl(align).unwrap_or(u32::MAX) > max_align {
 				return Err(Error::Validation(format!("Too large memory alignment 2^{} (expected at most {})", align, max_align)));
@@ -427,20 +429,20 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_block(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_block(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.push_label(BlockFrameType::Block, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_loop(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_loop(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.push_label(BlockFrameType::Loop, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_if(context: &mut FunctionValidationContext, block_type: BlockType) -> Result<InstructionOutcome, Error> {
+	fn validate_if(context: &mut FunctionValidationContext<E>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		context.push_label(BlockFrameType::IfTrue, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_else(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_else(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		let block_type = {
 			let top_frame = context.top_label()?;
 			if top_frame.frame_type != BlockFrameType::IfTrue {
@@ -456,7 +458,7 @@ impl Validator {
 		context.push_label(BlockFrameType::IfFalse, block_type).map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_end(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_end(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		{
 			let top_frame = context.top_label()?;
 			if top_frame.frame_type == BlockFrameType::IfTrue {
@@ -469,7 +471,7 @@ impl Validator {
 		context.pop_label().map(|_| InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
 		let (frame_type, frame_block_type) = {
 			let frame = context.require_label(idx)?;
 			(frame.frame_type, frame.block_type)
@@ -483,7 +485,7 @@ impl Validator {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_br_if(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_if(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
 		context.pop_value(ValueType::I32.into())?;
 		if let BlockType::Value(value_type) = context.require_label(idx)?.block_type {
 			context.tee_value(value_type.into())?;
@@ -491,7 +493,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_br_table(context: &mut FunctionValidationContext, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_br_table(context: &mut FunctionValidationContext<E>, table: &Vec<u32>, default: u32) -> Result<InstructionOutcome, Error> {
 		let mut required_block_type = None;
 		
 		{
@@ -523,14 +525,14 @@ impl Validator {
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_return(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_return(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		if let BlockType::Value(value_type) = context.return_type()? {
 			context.tee_value(value_type.into())?;
 		}
 		Ok(InstructionOutcome::Unreachable)
 	}
 
-	fn validate_call(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
 		let (argument_types, return_type) = context.require_function(idx)?;
 		for argument_type in argument_types.iter().rev() {
 			context.pop_value((*argument_type).into())?;
@@ -541,7 +543,7 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_call_indirect(context: &mut FunctionValidationContext, idx: u32) -> Result<InstructionOutcome, Error> {
+	fn validate_call_indirect(context: &mut FunctionValidationContext<E>, idx: u32) -> Result<InstructionOutcome, Error> {
 		context.require_table(DEFAULT_TABLE_INDEX, VariableType::AnyFunc)?;
 
 		context.pop_value(ValueType::I32.into())?;
@@ -555,13 +557,13 @@ impl Validator {
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_current_memory(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_current_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.push_value(ValueType::I32.into())?;
 		Ok(InstructionOutcome::ValidateNextInstruction)
 	}
 
-	fn validate_grow_memory(context: &mut FunctionValidationContext) -> Result<InstructionOutcome, Error> {
+	fn validate_grow_memory(context: &mut FunctionValidationContext<E>) -> Result<InstructionOutcome, Error> {
 		context.require_memory(DEFAULT_MEMORY_INDEX)?;
 		context.pop_value(ValueType::I32.into())?;
 		context.push_value(ValueType::I32.into())?;
@@ -569,10 +571,10 @@ impl Validator {
 	}
 }
 
-impl<'a> FunctionValidationContext<'a> {
+impl<'a, E> FunctionValidationContext<'a, E> where E: CustomUserError {
 	pub fn new(
-		module_instance: &'a ModuleInstance, 
-		externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface + 'a>>>,
+		module_instance: &'a ModuleInstance<E>, 
+		externals: Option<&'a HashMap<String, Arc<ModuleInstanceInterface<E> + 'a>>>,
 		locals: &'a [ValueType], 
 		value_stack_limit: usize, 
 		frame_stack_limit: usize, 

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -1,7 +1,7 @@
 use std::{i32, i64, u32, u64, f32};
 use std::io;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::variable::VariableType;
 
 /// Runtime value.
@@ -52,7 +52,7 @@ pub trait TransmuteInto<T> {
 }
 
 /// Convert from and to little endian.
-pub trait LittleEndianConvert<E: CustomUserError> where Self: Sized {
+pub trait LittleEndianConvert<E: UserError> where Self: Sized {
 	/// Convert to little endian buffer.
 	fn into_little_endian(self) -> Vec<u8>;
 	/// Convert from little endian buffer.
@@ -60,7 +60,7 @@ pub trait LittleEndianConvert<E: CustomUserError> where Self: Sized {
 }
 
 /// Arithmetic operations.
-pub trait ArithmeticOps<T, E: CustomUserError> {
+pub trait ArithmeticOps<T, E: UserError> {
 	/// Add two values.
 	fn add(self, other: T) -> T;
 	/// Subtract two values.
@@ -72,7 +72,7 @@ pub trait ArithmeticOps<T, E: CustomUserError> {
 }
 
 /// Integer value.
-pub trait Integer<T, E: CustomUserError>: ArithmeticOps<T, E> {
+pub trait Integer<T, E: UserError>: ArithmeticOps<T, E> {
 	/// Counts leading zeros in the bitwise representation of the value.
 	fn leading_zeros(self) -> T;
 	/// Counts trailing zeros in the bitwise representation of the value.
@@ -88,7 +88,7 @@ pub trait Integer<T, E: CustomUserError>: ArithmeticOps<T, E> {
 }
 
 /// Float-point value.
-pub trait Float<T, E: CustomUserError>: ArithmeticOps<T, E> {
+pub trait Float<T, E: UserError>: ArithmeticOps<T, E> {
 	/// Get absolute value.
 	fn abs(self) -> T;
 	/// Returns the largest integer less than or equal to a number.
@@ -178,7 +178,7 @@ impl From<f64> for RuntimeValue {
 	}
 }
 
-impl<E> TryInto<bool, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<bool, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<bool, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val != 0),
@@ -187,7 +187,7 @@ impl<E> TryInto<bool, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<i32, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<i32, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<i32, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val),
@@ -196,7 +196,7 @@ impl<E> TryInto<i32, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<i64, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<i64, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<i64, Error<E>> {
 		match self {
 			RuntimeValue::I64(val) => Ok(val),
@@ -205,7 +205,7 @@ impl<E> TryInto<i64, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<f32, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<f32, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<f32, Error<E>> {
 		match self {
 			RuntimeValue::F32(val) => Ok(val),
@@ -214,7 +214,7 @@ impl<E> TryInto<f32, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<f64, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<f64, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<f64, Error<E>> {
 		match self {
 			RuntimeValue::F64(val) => Ok(val),
@@ -223,7 +223,7 @@ impl<E> TryInto<f64, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<u32, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<u32, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<u32, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val as u32),
@@ -232,7 +232,7 @@ impl<E> TryInto<u32, Error<E>> for RuntimeValue where E: CustomUserError {
 	}
 }
 
-impl<E> TryInto<u64, Error<E>> for RuntimeValue where E: CustomUserError {
+impl<E> TryInto<u64, Error<E>> for RuntimeValue where E: UserError {
 	fn try_into(self) -> Result<u64, Error<E>> {
 		match self {
 			RuntimeValue::I64(val) => Ok(val as u64),
@@ -265,7 +265,7 @@ impl_wrap_into!(f64, f32);
 
 macro_rules! impl_try_truncate_into {
 	($from: ident, $into: ident) => {
-		impl<E> TryTruncateInto<$into, Error<E>> for $from where E: CustomUserError {
+		impl<E> TryTruncateInto<$into, Error<E>> for $from where E: UserError {
 			fn try_truncate_into(self) -> Result<$into, Error<E>> {
 				// Casting from a float to an integer will round the float towards zero
 				// NOTE: currently this will cause Undefined Behavior if the rounded value cannot be represented by the
@@ -373,7 +373,7 @@ impl TransmuteInto<f64> for i64 {
 	fn transmute_into(self) -> f64 { f64_from_bits(self as _) }
 }
 
-impl<E> LittleEndianConvert<E> for i8 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for i8 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		vec![self as u8]
 	}
@@ -385,7 +385,7 @@ impl<E> LittleEndianConvert<E> for i8 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for u8 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for u8 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		vec![self]
 	}
@@ -397,7 +397,7 @@ impl<E> LittleEndianConvert<E> for u8 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for i16 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for i16 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(2);
 		vec.write_i16::<LittleEndian>(self)
@@ -411,7 +411,7 @@ impl<E> LittleEndianConvert<E> for i16 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for u16 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for u16 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(2);
 		vec.write_u16::<LittleEndian>(self)
@@ -425,7 +425,7 @@ impl<E> LittleEndianConvert<E> for u16 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for i32 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for i32 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_i32::<LittleEndian>(self)
@@ -439,7 +439,7 @@ impl<E> LittleEndianConvert<E> for i32 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for u32 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for u32 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_u32::<LittleEndian>(self)
@@ -453,7 +453,7 @@ impl<E> LittleEndianConvert<E> for u32 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for i64 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for i64 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(8);
 		vec.write_i64::<LittleEndian>(self)
@@ -467,7 +467,7 @@ impl<E> LittleEndianConvert<E> for i64 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for f32 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for f32 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_f32::<LittleEndian>(self)
@@ -482,7 +482,7 @@ impl<E> LittleEndianConvert<E> for f32 where E: CustomUserError {
 	}
 }
 
-impl<E> LittleEndianConvert<E> for f64 where E: CustomUserError {
+impl<E> LittleEndianConvert<E> for f64 where E: UserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(8);
 		vec.write_f64::<LittleEndian>(self)
@@ -535,7 +535,7 @@ fn f64_from_bits(mut v: u64) -> f64 {
 
 macro_rules! impl_integer_arithmetic_ops {
 	($type: ident) => {
-		impl<E> ArithmeticOps<$type, E> for $type where E: CustomUserError {
+		impl<E> ArithmeticOps<$type, E> for $type where E: UserError {
 			fn add(self, other: $type) -> $type { self.wrapping_add(other) }
 			fn sub(self, other: $type) -> $type { self.wrapping_sub(other) }
 			fn mul(self, other: $type) -> $type { self.wrapping_mul(other) }
@@ -561,7 +561,7 @@ impl_integer_arithmetic_ops!(u64);
 
 macro_rules! impl_float_arithmetic_ops {
 	($type: ident) => {
-		impl<E> ArithmeticOps<$type, E> for $type where E: CustomUserError {
+		impl<E> ArithmeticOps<$type, E> for $type where E: UserError {
 			fn add(self, other: $type) -> $type { self + other }
 			fn sub(self, other: $type) -> $type { self - other }
 			fn mul(self, other: $type) -> $type { self * other }
@@ -575,7 +575,7 @@ impl_float_arithmetic_ops!(f64);
 
 macro_rules! impl_integer {
 	($type: ident) => {
-		impl<E> Integer<$type, E> for $type where E: CustomUserError {
+		impl<E> Integer<$type, E> for $type where E: UserError {
 			fn leading_zeros(self) -> $type { self.leading_zeros() as $type }
 			fn trailing_zeros(self) -> $type { self.trailing_zeros() as $type }
 			fn count_ones(self) -> $type { self.count_ones() as $type }
@@ -596,7 +596,7 @@ impl_integer!(u64);
 
 macro_rules! impl_float {
 	($type: ident, $int_type: ident) => {
-		impl<E> Float<$type, E> for $type where E: CustomUserError {
+		impl<E> Float<$type, E> for $type where E: UserError {
 			fn abs(self) -> $type { self.abs() }
 			fn floor(self) -> $type { self.floor() }
 			fn ceil(self) -> $type { self.ceil() }

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -1,7 +1,7 @@
 use std::{i32, i64, u32, u64, f32};
 use std::io;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use interpreter::Error;
+use interpreter::{Error, CustomUserError};
 use interpreter::variable::VariableType;
 
 /// Runtime value.
@@ -52,15 +52,15 @@ pub trait TransmuteInto<T> {
 }
 
 /// Convert from and to little endian.
-pub trait LittleEndianConvert where Self: Sized {
+pub trait LittleEndianConvert<E: CustomUserError> where Self: Sized {
 	/// Convert to little endian buffer.
 	fn into_little_endian(self) -> Vec<u8>;
 	/// Convert from little endian buffer.
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error>;
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>>;
 }
 
 /// Arithmetic operations.
-pub trait ArithmeticOps<T> {
+pub trait ArithmeticOps<T, E: CustomUserError> {
 	/// Add two values.
 	fn add(self, other: T) -> T;
 	/// Subtract two values.
@@ -68,11 +68,11 @@ pub trait ArithmeticOps<T> {
 	/// Multiply two values.
 	fn mul(self, other: T) -> T;
 	/// Divide two values.
-	fn div(self, other: T) -> Result<T, Error>;
+	fn div(self, other: T) -> Result<T, Error<E>>;
 }
 
 /// Integer value.
-pub trait Integer<T>: ArithmeticOps<T> {
+pub trait Integer<T, E: CustomUserError>: ArithmeticOps<T, E> {
 	/// Counts leading zeros in the bitwise representation of the value.
 	fn leading_zeros(self) -> T;
 	/// Counts trailing zeros in the bitwise representation of the value.
@@ -84,11 +84,11 @@ pub trait Integer<T>: ArithmeticOps<T> {
 	/// Get right bit rotation result.
 	fn rotr(self, other: T) -> T;
 	/// Get division remainder.
-	fn rem(self, other: T) -> Result<T, Error>;
+	fn rem(self, other: T) -> Result<T, Error<E>>;
 }
 
 /// Float-point value.
-pub trait Float<T>: ArithmeticOps<T> {
+pub trait Float<T, E: CustomUserError>: ArithmeticOps<T, E> {
 	/// Get absolute value.
 	fn abs(self) -> T;
 	/// Returns the largest integer less than or equal to a number.
@@ -178,8 +178,8 @@ impl From<f64> for RuntimeValue {
 	}
 }
 
-impl TryInto<bool, Error> for RuntimeValue {
-	fn try_into(self) -> Result<bool, Error> {
+impl<E> TryInto<bool, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<bool, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val != 0),
 			_ => Err(Error::Value(format!("32-bit int value expected"))),
@@ -187,8 +187,8 @@ impl TryInto<bool, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<i32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<i32, Error> {
+impl<E> TryInto<i32, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<i32, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val),
 			_ => Err(Error::Value(format!("32-bit int value expected"))),
@@ -196,8 +196,8 @@ impl TryInto<i32, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<i64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<i64, Error> {
+impl<E> TryInto<i64, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<i64, Error<E>> {
 		match self {
 			RuntimeValue::I64(val) => Ok(val),
 			_ => Err(Error::Value(format!("64-bit int value expected"))),
@@ -205,8 +205,8 @@ impl TryInto<i64, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<f32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<f32, Error> {
+impl<E> TryInto<f32, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<f32, Error<E>> {
 		match self {
 			RuntimeValue::F32(val) => Ok(val),
 			_ => Err(Error::Value(format!("32-bit float value expected"))),
@@ -214,8 +214,8 @@ impl TryInto<f32, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<f64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<f64, Error> {
+impl<E> TryInto<f64, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<f64, Error<E>> {
 		match self {
 			RuntimeValue::F64(val) => Ok(val),
 			_ => Err(Error::Value(format!("64-bit float value expected"))),
@@ -223,8 +223,8 @@ impl TryInto<f64, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<u32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<u32, Error> {
+impl<E> TryInto<u32, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<u32, Error<E>> {
 		match self {
 			RuntimeValue::I32(val) => Ok(val as u32),
 			_ => Err(Error::Value(format!("32-bit int value expected"))),
@@ -232,8 +232,8 @@ impl TryInto<u32, Error> for RuntimeValue {
 	}
 }
 
-impl TryInto<u64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<u64, Error> {
+impl<E> TryInto<u64, Error<E>> for RuntimeValue where E: CustomUserError {
+	fn try_into(self) -> Result<u64, Error<E>> {
 		match self {
 			RuntimeValue::I64(val) => Ok(val as u64),
 			_ => Err(Error::Value(format!("64-bit int value expected"))),
@@ -265,8 +265,8 @@ impl_wrap_into!(f64, f32);
 
 macro_rules! impl_try_truncate_into {
 	($from: ident, $into: ident) => {
-		impl TryTruncateInto<$into, Error> for $from {
-			fn try_truncate_into(self) -> Result<$into, Error> {
+		impl<E> TryTruncateInto<$into, Error<E>> for $from where E: CustomUserError {
+			fn try_truncate_into(self) -> Result<$into, Error<E>> {
 				// Casting from a float to an integer will round the float towards zero
 				// NOTE: currently this will cause Undefined Behavior if the rounded value cannot be represented by the
 				// target integer type. This includes Inf and NaN. This is a bug and will be fixed.
@@ -373,31 +373,31 @@ impl TransmuteInto<f64> for i64 {
 	fn transmute_into(self) -> f64 { f64_from_bits(self as _) }
 }
 
-impl LittleEndianConvert for i8 {
+impl<E> LittleEndianConvert<E> for i8 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		vec![self as u8]
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		buffer.get(0)
 			.map(|v| *v as i8)
 			.ok_or(Error::Value("invalid little endian buffer".into()))
 	}
 }
 
-impl LittleEndianConvert for u8 {
+impl<E> LittleEndianConvert<E> for u8 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		vec![self]
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		buffer.get(0)
 			.cloned()
 			.ok_or(Error::Value("invalid little endian buffer".into()))
 	}
 }
 
-impl LittleEndianConvert for i16 {
+impl<E> LittleEndianConvert<E> for i16 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(2);
 		vec.write_i16::<LittleEndian>(self)
@@ -405,13 +405,13 @@ impl LittleEndianConvert for i16 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_i16::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for u16 {
+impl<E> LittleEndianConvert<E> for u16 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(2);
 		vec.write_u16::<LittleEndian>(self)
@@ -419,13 +419,13 @@ impl LittleEndianConvert for u16 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_u16::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for i32 {
+impl<E> LittleEndianConvert<E> for i32 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_i32::<LittleEndian>(self)
@@ -433,13 +433,13 @@ impl LittleEndianConvert for i32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_i32::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for u32 {
+impl<E> LittleEndianConvert<E> for u32 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_u32::<LittleEndian>(self)
@@ -447,13 +447,13 @@ impl LittleEndianConvert for u32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_u32::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for i64 {
+impl<E> LittleEndianConvert<E> for i64 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(8);
 		vec.write_i64::<LittleEndian>(self)
@@ -461,13 +461,13 @@ impl LittleEndianConvert for i64 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_i64::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for f32 {
+impl<E> LittleEndianConvert<E> for f32 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(4);
 		vec.write_f32::<LittleEndian>(self)
@@ -475,14 +475,14 @@ impl LittleEndianConvert for f32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_u32::<LittleEndian>()
 			.map(f32_from_bits)
 			.map_err(|e| Error::Value(e.to_string()))
 	}
 }
 
-impl LittleEndianConvert for f64 {
+impl<E> LittleEndianConvert<E> for f64 where E: CustomUserError {
 	fn into_little_endian(self) -> Vec<u8> {
 		let mut vec = Vec::with_capacity(8);
 		vec.write_f64::<LittleEndian>(self)
@@ -490,7 +490,7 @@ impl LittleEndianConvert for f64 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error<E>> {
 		io::Cursor::new(buffer).read_u64::<LittleEndian>()
 			.map(f64_from_bits)
 			.map_err(|e| Error::Value(e.to_string()))
@@ -535,11 +535,11 @@ fn f64_from_bits(mut v: u64) -> f64 {
 
 macro_rules! impl_integer_arithmetic_ops {
 	($type: ident) => {
-		impl ArithmeticOps<$type> for $type {
+		impl<E> ArithmeticOps<$type, E> for $type where E: CustomUserError {
 			fn add(self, other: $type) -> $type { self.wrapping_add(other) }
 			fn sub(self, other: $type) -> $type { self.wrapping_sub(other) }
 			fn mul(self, other: $type) -> $type { self.wrapping_mul(other) }
-			fn div(self, other: $type) -> Result<$type, Error> { 
+			fn div(self, other: $type) -> Result<$type, Error<E>> { 
 				if other == 0 { Err(Error::Value("Division by zero".to_owned())) }
 				else {
 					let (result, overflow) = self.overflowing_div(other);
@@ -561,11 +561,11 @@ impl_integer_arithmetic_ops!(u64);
 
 macro_rules! impl_float_arithmetic_ops {
 	($type: ident) => {
-		impl ArithmeticOps<$type> for $type {
+		impl<E> ArithmeticOps<$type, E> for $type where E: CustomUserError {
 			fn add(self, other: $type) -> $type { self + other }
 			fn sub(self, other: $type) -> $type { self - other }
 			fn mul(self, other: $type) -> $type { self * other }
-			fn div(self, other: $type) -> Result<$type, Error> { Ok(self / other) }
+			fn div(self, other: $type) -> Result<$type, Error<E>> { Ok(self / other) }
 		}
 	}
 }
@@ -575,13 +575,13 @@ impl_float_arithmetic_ops!(f64);
 
 macro_rules! impl_integer {
 	($type: ident) => {
-		impl Integer<$type> for $type {
+		impl<E> Integer<$type, E> for $type where E: CustomUserError {
 			fn leading_zeros(self) -> $type { self.leading_zeros() as $type }
 			fn trailing_zeros(self) -> $type { self.trailing_zeros() as $type }
 			fn count_ones(self) -> $type { self.count_ones() as $type }
 			fn rotl(self, other: $type) -> $type { self.rotate_left(other as u32) }
 			fn rotr(self, other: $type) -> $type { self.rotate_right(other as u32) }
-			fn rem(self, other: $type) -> Result<$type, Error> { 
+			fn rem(self, other: $type) -> Result<$type, Error<E>> { 
 				if other == 0 { Err(Error::Value("Division by zero".to_owned())) } 
 				else { Ok(self.wrapping_rem(other)) } 
 			}
@@ -596,7 +596,7 @@ impl_integer!(u64);
 
 macro_rules! impl_float {
 	($type: ident, $int_type: ident) => {
-		impl Float<$type> for $type {
+		impl<E> Float<$type, E> for $type where E: CustomUserError {
 			fn abs(self) -> $type { self.abs() }
 			fn floor(self) -> $type { self.floor() }
 			fn ceil(self) -> $type { self.ceil() }

--- a/src/interpreter/variable.rs
+++ b/src/interpreter/variable.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use parking_lot::RwLock;
 use elements::{GlobalType, ValueType, TableElementType};
-use interpreter::{Error, CustomUserError};
+use interpreter::{Error, UserError};
 use interpreter::value::RuntimeValue;
 
 /// Variable type.
@@ -20,7 +20,7 @@ pub enum VariableType {
 }
 
 /// Externally stored variable value.
-pub trait ExternalVariableValue<E: CustomUserError> {
+pub trait ExternalVariableValue<E: UserError> {
 	/// Get variable value.
 	fn get(&self) -> RuntimeValue;
 	/// Set variable value.
@@ -29,7 +29,7 @@ pub trait ExternalVariableValue<E: CustomUserError> {
 
 /// Variable instance.
 #[derive(Debug)]
-pub struct VariableInstance<E: CustomUserError> {
+pub struct VariableInstance<E: UserError> {
 	/// Is mutable?
 	is_mutable: bool,
 	/// Variable type.
@@ -39,14 +39,14 @@ pub struct VariableInstance<E: CustomUserError> {
 }
 
 /// Enum variable value.
-enum VariableValue<E: CustomUserError> {
+enum VariableValue<E: UserError> {
 	/// Internal value.
 	Internal(RuntimeValue),
 	/// External value.
 	External(Box<ExternalVariableValue<E>>),
 }
 
-impl<E> VariableInstance<E> where E: CustomUserError {
+impl<E> VariableInstance<E> where E: UserError {
 	/// New variable instance
 	pub fn new(is_mutable: bool, variable_type: VariableType, value: RuntimeValue) -> Result<Self, Error<E>> {
 		// TODO: there is nothing about null value in specification + there is nothing about initializing missing table elements? => runtime check for nulls
@@ -109,7 +109,7 @@ impl<E> VariableInstance<E> where E: CustomUserError {
 	}
 }
 
-impl<E> VariableValue<E> where E: CustomUserError {
+impl<E> VariableValue<E> where E: UserError {
 	fn get(&self) -> RuntimeValue {
 		match *self {
 			VariableValue::Internal(ref value) => value.clone(),
@@ -147,7 +147,7 @@ impl From<TableElementType> for VariableType {
 	}
 }
 
-impl<E> fmt::Debug for VariableValue<E> where E: CustomUserError {
+impl<E> fmt::Debug for VariableValue<E> where E: UserError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			VariableValue::Internal(ref value) => write!(f, "Variable.Internal({:?})", value),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@ pub use elements::{
 
 pub use interpreter::{
     ProgramInstance,
-    CustomProgramInstance,
+    DefaultProgramInstance,
     ModuleInstance,
-    CustomModuleInstance,
+    DefaultModuleInstance,
     ModuleInstanceInterface,
-    CustomModuleInstanceInterface,
+    DefaultModuleInstanceInterface,
     RuntimeValue,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@ pub use elements::{
 
 pub use interpreter::{
     ProgramInstance,
+    CustomProgramInstance,
     ModuleInstance,
+    CustomModuleInstance,
     ModuleInstanceInterface,
+    CustomModuleInstanceInterface,
     RuntimeValue,
 };


### PR DESCRIPTION
closes #20 

Most significant API changes:
1) most of interpreter structs are now generic over user error type
2) there is default dummy user error type - DummyCustorError (empty struct) && aliases for most used client API types - DefaultProgramInstance = ProgramInstance<DummyCustorError>, DefaultModuleInstance, DefaultModuleInstanceInterface
3) every custom user error type msut implement CustomUserError trait which is currently just `: ::std::fmt::Display + ::std::fmt::Debug + Clone + PartialEq`

Most of changes are just cosmetic (propagating generic parameter). Example is in `native_custom_error`