### PR TITLE
Add cargo-fuzz testing for deserialize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "spec/wabt"]
 	path = spec/wabt
 	url = https://github.com/WebAssembly/wabt
+[submodule "fuzz/binaryen"]
+	path = fuzz/binaryen
+	url = https://github.com/WebAssembly/binaryen

--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ println!("Function count in wasm file: {}", code_section.bodies().len());
 
 ## Wabt Test suite
 
-Interpreter and decoder supports full wabt testsuite (https://github.com/WebAssembly/testsuite), To run testsuite: 
+Interpreter and decoder supports full wabt testsuite (https://github.com/WebAssembly/testsuite), To run testsuite:
 
 - make sure you have all prerequisites to build `wabt` (since parity-wasm builds it internally using `cmake`, see https://github.com/WebAssembly/wabt)
 - checkout with submodules (`git submodule update --init --recurive`)
 - run `cargo test --release --manifest-path=spec/Cargo.toml`
+
+Decoder can be fuzzed with `cargo-fuzz` using `wasm-opt` (https://githib.com/WebAssembly/binaryen):
+
+- make sure you have all prerequisites to build `binaryen` and `cargo-fuzz` (`cmake` and a C++11 toolchain)
+- checkout with submodules (`git submodule update --init --recursive`)
+- install `cargo fuzz` subcommand with `cargo install cargo-fuzz`
+- set rustup to use a nightly toolchain, because `cargo fuzz` uses a rust compiler plugin: `rustup override set nightly`
+- run `cargo fuzz run deserialize`
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Interpreter and decoder supports full wabt testsuite (https://github.com/WebAsse
 - checkout with submodules (`git submodule update --init --recurive`)
 - run `cargo test --release --manifest-path=spec/Cargo.toml`
 
-Decoder can be fuzzed with `cargo-fuzz` using `wasm-opt` (https://githib.com/WebAssembly/binaryen):
+Decoder can be fuzzed with `cargo-fuzz` using `wasm-opt` (https://github.com/WebAssembly/binaryen):
 
 - make sure you have all prerequisites to build `binaryen` and `cargo-fuzz` (`cmake` and a C++11 toolchain)
 - checkout with submodules (`git submodule update --init --recursive`)

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,8 +2,12 @@
 [package]
 name = "parity-wasm-fuzz"
 version = "0.0.1"
-authors = ["Automatically generated"]
+authors = ["Pat Hickey phickey@fastly.com"]
 publish = false
+build = "build.rs"
+
+[build-dependencies]
+cmake = "0.1"
 
 [package.metadata]
 cargo-fuzz = true
@@ -21,5 +25,5 @@ version = "0.3.1"
 members = ["."]
 
 [[bin]]
-name = "fuzz_decode"
-path = "fuzz_targets/fuzz_decode.rs"
+name = "deserialize"
+path = "fuzz_targets/deserialize.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+
+[package]
+name = "parity-wasm-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.parity-wasm]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies.mktemp]
+version = "0.3.1"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_decode"
+path = "fuzz_targets/fuzz_decode.rs"

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,0 +1,7 @@
+extern crate cmake;
+use cmake::Config;
+
+fn main() {
+    let _dst = Config::new("binaryen")
+        .build();
+}

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -6,8 +6,17 @@ extern crate mktemp;
 
 use std::fs::File;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::Command;
 
+fn wasm_opt() -> PathBuf {
+    let bin = PathBuf::from(env!("OUT_DIR")).join("bin").join("wasm-opt");
+    assert!(
+        bin.exists(),
+        format!("could not find wasm-opt at: {:?}", wasm_opt())
+    );
+    bin
+}
 
 fuzz_target!(|data: &[u8]| {
     let seed = mktemp::Temp::new_file().unwrap();
@@ -16,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     seedfile.flush().unwrap();
 
     let wasm = mktemp::Temp::new_file().unwrap();
-    let opt_fuzz = Command::new("wasm-opt")
+    let opt_fuzz = Command::new(wasm_opt())
         .arg("--translate-to-fuzz")
         .arg(seed.as_ref())
         .arg("-o")

--- a/fuzz/fuzz_targets/fuzz_decode.rs
+++ b/fuzz/fuzz_targets/fuzz_decode.rs
@@ -1,0 +1,37 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate parity_wasm;
+extern crate mktemp;
+
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+
+
+fuzz_target!(|data: &[u8]| {
+    let seed = mktemp::Temp::new_file().unwrap();
+    let mut seedfile = File::create(seed.as_ref()).unwrap();
+    seedfile.write_all(data).unwrap();
+    seedfile.flush().unwrap();
+
+    let wasm = mktemp::Temp::new_file().unwrap();
+    let opt_fuzz = Command::new("wasm-opt")
+        .arg("--translate-to-fuzz")
+        .arg(seed.as_ref())
+        .arg("-o")
+        .arg(wasm.as_ref())
+        .output()
+        .unwrap();
+
+    assert!(
+        opt_fuzz.status.success(),
+        format!(
+            "wasm-opt failed with: {}",
+            String::from_utf8_lossy(&opt_fuzz.stderr)
+        )
+    );
+
+    let _module: parity_wasm::elements::Module = parity_wasm::deserialize_file(wasm.as_ref())
+        .unwrap();
+});


### PR DESCRIPTION
For bug #94 

I added `binaryen` as a submodule under `fuzz/`, and a `build.rs` in there to build it with cmake. Dependency installation and running is described in the README.